### PR TITLE
Update and tweak

### DIFF
--- a/RockLib.Configuration.UnitTests/RockLib.Configuration.UnitTests.csproj
+++ b/RockLib.Configuration.UnitTests/RockLib.Configuration.UnitTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-    <PackageReference Include="RockLib.Immutable" Version="0.0.1-alpha01" />
+    <PackageReference Include="RockLib.Immutable" Version="0.0.1-alpha02" />
   </ItemGroup>
     
   <ItemGroup>

--- a/RockLib.Configuration/LateBoundConfigurationSection.cs
+++ b/RockLib.Configuration/LateBoundConfigurationSection.cs
@@ -54,7 +54,7 @@ namespace RockLib.Configuration
         {
             var type = System.Type.GetType(assemblyQualifiedName, true, true);
             if (!typeof(T).GetTypeInfo().IsAssignableFrom(type))
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"Unable to set the Type property. The specified value, '{assemblyQualifiedName}', is not assignable to type '{typeof(T).Name}'.");
             return type;
         }
 

--- a/RockLib.Configuration/RockLib.Configuration.csproj
+++ b/RockLib.Configuration/RockLib.Configuration.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-    <PackageReference Include="RockLib.Immutable" Version="0.0.1-alpha01" />
+    <PackageReference Include="RockLib.Immutable" Version="0.0.1-alpha02" />
   </ItemGroup>
     
 </Project>


### PR DESCRIPTION
- Update RockLib.Immutable package
- Add useful exception message when passing invalid value to `LateBoundConfigurationSection.Type` property. The exception message had been left blank by mistake.