### PR TITLE
Add proxy factory

### DIFF
--- a/RockLib.Configuration.ProxyFactory.UnitTests/ProxyFactoryTests.cs
+++ b/RockLib.Configuration.ProxyFactory.UnitTests/ProxyFactoryTests.cs
@@ -1,0 +1,267 @@
+﻿using Microsoft.Extensions.Configuration;
+using RockLib.Configuration.ProxyFactory;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Tests
+{
+    public class ProxyFactoryTests
+    {
+        [Fact]
+        public void NonGeneric_CanCreateProxyForReadonlyProperties()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+            var fooObject = fooSection.CreateProxy(typeof(IReadonlyProperties));
+
+            Assert.IsAssignableFrom<IReadonlyProperties>(fooObject);
+
+            var foo = (IReadonlyProperties)fooObject;
+
+            Assert.Equal("abcdefg", foo.Bar);
+            Assert.Equal(123, foo.Baz);
+        }
+
+        [Fact]
+        public void NonGeneric_CanCreateProxyForReadWriteProperties()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+            var fooObject = fooSection.CreateProxy(typeof(IReadWriteProperties));
+
+            Assert.IsAssignableFrom<IReadWriteProperties>(fooObject);
+
+            var foo = (IReadWriteProperties)fooObject;
+
+            Assert.Equal("abcdefg", foo.Bar);
+            Assert.Equal(123, foo.Baz);
+
+            // Make sure getters and setters work as expected.
+            foo.Bar = "wxyz";
+            foo.Baz = 789;
+
+            Assert.Equal("wxyz", foo.Bar);
+            Assert.Equal(789, foo.Baz);
+        }
+
+        [Fact]
+        public void Generic_CanCreateProxyForReadonlyProperties()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+            var foo = fooSection.CreateProxy<IReadonlyProperties>();
+
+            Assert.Equal("abcdefg", foo.Bar);
+            Assert.Equal(123, foo.Baz);
+        }
+
+        [Fact]
+        public void Generic_CanCreateProxyForReadWriteProperties()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+            var foo = fooSection.CreateProxy<IReadWriteProperties>();
+
+            Assert.Equal("abcdefg", foo.Bar);
+            Assert.Equal(123, foo.Baz);
+
+            // Make sure getters and setters work as expected.
+            foo.Bar = "wxyz";
+            foo.Baz = 789;
+
+            Assert.Equal("wxyz", foo.Bar);
+            Assert.Equal(789, foo.Baz);
+        }
+
+        [Fact]
+        public void NonGeneric_GivenNullConfiguration_ThrowsArgumentNullException()
+        {
+            IConfiguration fooSection = null;
+
+            Assert.Throws<ArgumentNullException>(() => fooSection.CreateProxy(typeof(IReadonlyProperties)));
+        }
+
+        [Fact]
+        public void NonGeneric_GivenNullType_ThrowsArgumentNullException()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+
+            Assert.Throws<ArgumentNullException>(() => fooSection.CreateProxy(null));
+        }
+
+        [Fact]
+        public void Generic_GivenNullConfiguration_ThrowsArgumentNullException()
+        {
+            IConfiguration fooSection = null;
+
+            Assert.Throws<ArgumentNullException>(() => fooSection.CreateProxy<IReadonlyProperties>());
+        }
+
+        [Fact]
+        public void GivenTypeIsNotAnInterface_ThrowsArgumentException()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+
+            var ex = Assert.Throws<ArgumentException>(() => fooSection.CreateProxy<NotAnInterface>());
+
+#if DEBUG
+            var expected = Exceptions.CannotCreateProxyOfNonInterfaceType(typeof(NotAnInterface));
+            Assert.Equal(expected.Message, ex.Message);
+#endif
+        }
+
+        [Fact]
+        public void GivenInterfaceTypeDefinesAMethod_ThrowsArgumentException()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+
+            var ex = Assert.Throws<ArgumentException>(() => fooSection.CreateProxy<IHasMethod>());
+
+#if DEBUG
+            var expected = Exceptions.TargetInterfaceCannotHaveAnyMethods(typeof(IHasMethod), typeof(IHasMethod).GetTypeInfo().GetMethod("Foo"));
+            Assert.Equal(expected.Message, ex.Message);
+#endif
+        }
+
+        [Fact]
+        public void GivenInterfaceTypeDefinesAnEvent_ThrowsArgumentException()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+
+            var ex = Assert.Throws<ArgumentException>(() => fooSection.CreateProxy<IHasEvent>());
+
+#if DEBUG
+            var expected = Exceptions.TargetInterfaceCannotHaveAnyEvents(typeof(IHasEvent), typeof(IHasEvent).GetTypeInfo().GetEvent("Foo"));
+            Assert.Equal(expected.Message, ex.Message);
+#endif
+        }
+
+        [Fact]
+        public void GivenInterfaceTypeDefinesAnIndexerProperty_ThrowsArgumentException()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+
+            var ex = Assert.Throws<ArgumentException>(() => fooSection.CreateProxy<IHasIndexerProperty>());
+
+#if DEBUG
+            var expected = Exceptions.TargetInterfaceCannotHaveAnyIndexerProperties(typeof(IHasIndexerProperty), typeof(IHasIndexerProperty).GetTypeInfo().GetProperties()[0]);
+            Assert.Equal(expected.Message, ex.Message);
+#endif
+        }
+
+        [Fact]
+        public void GivenInterfaceTypeDefinesAWriteOnlyProperty_ThrowsArgumentException()
+        {
+            var config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                    { "foo:bar", "abcdefg" },
+                    { "foo:baz", "123" },
+               }).Build();
+
+            var fooSection = config.GetSection("foo");
+
+            var ex = Assert.Throws<ArgumentException>(() => fooSection.CreateProxy<IHasWriteOnlyProperty>());
+
+#if DEBUG
+            var expected = Exceptions.TargetInterfaceCannotHaveAnyWriteOnlyProperties(typeof(IHasWriteOnlyProperty), typeof(IHasWriteOnlyProperty).GetTypeInfo().GetProperty("Foo"));
+            Assert.Equal(expected.Message, ex.Message);
+#endif
+        }
+
+        public interface IReadonlyProperties
+        {
+            string Bar { get; }
+            int Baz { get; }
+        }
+
+        public interface IReadWriteProperties
+        {
+            string Bar { get; set; }
+            int Baz { get; set; }
+        }
+
+        public class NotAnInterface { }
+
+        public interface IHasMethod
+        {
+            void Foo();
+        }
+
+        public interface IHasEvent
+        {
+            event EventHandler Foo;
+        }
+
+        public interface IHasIndexerProperty
+        {
+            int this[string foo] { get; set; }
+        }
+
+        public interface IHasWriteOnlyProperty
+        {
+            int Foo { set; }
+        }
+    }
+}

--- a/RockLib.Configuration.ProxyFactory.UnitTests/RockLib.Configuration.ProxyFactory.UnitTests.csproj
+++ b/RockLib.Configuration.ProxyFactory.UnitTests/RockLib.Configuration.ProxyFactory.UnitTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>    
+    <TargetFramework>netcoreapp1.1</TargetFramework>    
+    <RootNamespace>Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="0.0.1-alpha01" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RockLib.Configuration.ProxyFactory\RockLib.Configuration.ProxyFactory.csproj" />
+  </ItemGroup>
+    
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -9,6 +9,9 @@ using System.Reflection.Emit;
 
 namespace RockLib.Configuration.ProxyFactory
 {
+    /// <summary>
+    /// Static class that creates proxy instances of interfaces from configuration values.
+    /// </summary>
     public static class ConfigurationProxyFactory
     {
         private const TypeAttributes _typeAttributes = TypeAttributes.NotPublic | TypeAttributes.Class | TypeAttributes.AutoClass | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.AutoLayout;
@@ -16,9 +19,62 @@ namespace RockLib.Configuration.ProxyFactory
 
         private static readonly ConcurrentDictionary<Type, Type> _proxyCache = new ConcurrentDictionary<Type, Type>();
 
+        /// <summary>
+        /// Returns an instance of a proxy type that implements the interface specified by the <typeparamref name="T"/>
+        /// type parameter and has values specified by the <paramref name="configuration"/> parameter.
+        /// </summary>
+        /// <remarks>
+        /// This method uses the <see cref="ConfigurationObjectFactory.Create(IConfiguration, Type, DefaultTypes, ValueConverters)"/>
+        /// method to create instances of proxy types and can throw any of the exception that it throws.
+        /// </remarks>
+        /// <typeparam name="T">An interface with readable properties.</typeparam>
+        /// <param name="configuration">The configuration to create the proxy object from.</param>
+        /// <param name="defaultTypes">
+        /// An object that defines the default types to be used when a type is not explicitly specified by a
+        /// configuration section.
+        /// </param>
+        /// <param name="valueConverters">
+        /// An object that defines custom converter functions that are used to convert string configuration
+        /// values to a target type.
+        /// </param>
+        /// <returns>
+        /// An object that implements the interface specified by the <paramref name="type"/> parameter containing values from the
+        /// <paramref name="configuration"/> parameter.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="configuration"/> is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// If <typeparamref name="T"/> is not an interface or has any declared methods, events, or write-only properties.
+        /// </exception>
         public static T CreateProxy<T>(this IConfiguration configuration, DefaultTypes defaultTypes = null, ValueConverters valueConverters = null) =>
             (T)configuration.CreateProxy(typeof(T), defaultTypes, valueConverters);
 
+        /// <summary>
+        /// Returns an instance of a proxy type that implements the interface specified by the <paramref name="type"/>
+        /// parameter and has values specified by the <paramref name="configuration"/> parameter.
+        /// <para></para>
+        /// </summary>
+        /// <remarks>
+        /// This method uses the <see cref="ConfigurationObjectFactory.Create(IConfiguration, Type, DefaultTypes, ValueConverters)"/>
+        /// method to create instances of proxy types and can throw any of the exception that it throws.
+        /// </remarks>
+        /// <param name="configuration">The configuration to create the proxy object from.</param>
+        /// <param name="type">An interface with readable properties.</param>
+        /// <param name="defaultTypes">
+        /// An object that defines the default types to be used when a type is not explicitly specified by a
+        /// configuration section.
+        /// </param>
+        /// <param name="valueConverters">
+        /// An object that defines custom converter functions that are used to convert string configuration
+        /// values to a target type.
+        /// </param>
+        /// <returns>
+        /// An object that implements the interface specified by the <paramref name="type"/> parameter containing values from the
+        /// <paramref name="configuration"/> parameter.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="configuration"/> or <paramref name="type"/> is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="type"/> is not an interface or has any declared methods, events, or write-only properties.
+        /// </exception>
         public static object CreateProxy(this IConfiguration configuration, Type type, DefaultTypes defaultTypes = null, ValueConverters valueConverters = null)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -1,0 +1,142 @@
+﻿using Microsoft.Extensions.Configuration;
+using RockLib.Configuration.ObjectFactory;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace RockLib.Configuration.ProxyFactory
+{
+    public static class ConfigurationProxyFactory
+    {
+        private static readonly ConcurrentDictionary<Type, Type> _proxyCache = new ConcurrentDictionary<Type, Type>();
+
+        public static T CreateProxy<T>(this IConfiguration configuration, DefaultTypes defaultTypes = null, ValueConverters valueConverters = null) =>
+            (T)configuration.CreateProxy(typeof(T), defaultTypes, valueConverters);
+
+        public static object CreateProxy(this IConfiguration configuration, Type type, DefaultTypes defaultTypes = null, ValueConverters valueConverters = null)
+        {
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            var proxyType = _proxyCache.GetOrAdd(type, CreateProxyType);
+            return configuration.Create(proxyType, defaultTypes, valueConverters);
+        }
+
+        private static Type CreateProxyType(Type type)
+        {
+            ValidateType(type);
+            const TypeAttributes classTypeAttributes =
+                TypeAttributes.NotPublic | TypeAttributes.Class | TypeAttributes.AutoClass
+                | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.AutoLayout;
+
+            var name = "<" + type.Name + ">__RockLibConfigurationProxy";
+            var interfaces = new[] { type };
+
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName("<" + name + ">__RockLibConfigurationDynamicAssembly"), AssemblyBuilderAccess.Run);
+
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+
+            var typeBuilder = moduleBuilder.DefineType(name, classTypeAttributes, typeof(object), interfaces);
+
+            var readonlyFields = new List<Tuple<string, FieldBuilder>>();
+
+            foreach (var property in type.GetTypeInfo().GetProperties())
+            {
+                const MethodAttributes methodAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.Virtual;
+                var backingFieldName = "<" + property.Name + ">k__BackingField";
+
+                if (property.CanWrite)
+                {
+                    var fieldBuilder = typeBuilder.DefineField(backingFieldName, property.PropertyType, FieldAttributes.Private);
+                    var propertyBuilder = typeBuilder.DefineProperty(property.Name, PropertyAttributes.HasDefault, property.PropertyType, null);
+                    var getMethodBuilder = GetGetMethodBuilder(property.Name, property.PropertyType, typeBuilder, methodAttributes, fieldBuilder);
+                    var setMethodBuilder = GetSetMethodBuilder(property.Name, property.PropertyType, typeBuilder, methodAttributes, fieldBuilder);
+                    propertyBuilder.SetGetMethod(getMethodBuilder);
+                    propertyBuilder.SetSetMethod(setMethodBuilder);
+                }
+                else
+                {
+                    var fieldBuilder = typeBuilder.DefineField(backingFieldName, property.PropertyType, FieldAttributes.Private | FieldAttributes.InitOnly);
+                    var propertyBuilder = typeBuilder.DefineProperty(property.Name, PropertyAttributes.None, property.PropertyType, null);
+                    var getMethodBuilder = GetGetMethodBuilder(property.Name, property.PropertyType, typeBuilder, methodAttributes, fieldBuilder);
+                    propertyBuilder.SetGetMethod(getMethodBuilder);
+                    readonlyFields.Add(Tuple.Create(property.Name, fieldBuilder));
+                }
+            }
+
+            var constructorBuilder = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, readonlyFields.Select(f => f.Item2.FieldType).ToArray());
+            var il = constructorBuilder.GetILGenerator();
+            for (int i = 0; i < readonlyFields.Count; i++)
+            {
+                constructorBuilder.DefineParameter(i + 1, ParameterAttributes.None, readonlyFields[i].Item1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldarg, i + 1);
+                il.Emit(OpCodes.Stfld, readonlyFields[i].Item2);
+            }
+
+            il.Emit(OpCodes.Ret);
+
+            return typeBuilder.CreateTypeInfo().AsType();
+        }
+
+        private static MethodBuilder GetGetMethodBuilder(string name, Type type,
+            TypeBuilder tb, MethodAttributes methodAttributes, FieldBuilder fieldBuilder)
+        {
+            var getMethodBuilder = tb.DefineMethod("get_" + name,
+                methodAttributes, type, Type.EmptyTypes);
+            var il = getMethodBuilder.GetILGenerator();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, fieldBuilder);
+
+            il.Emit(OpCodes.Ret);
+            return getMethodBuilder;
+        }
+
+        private static MethodBuilder GetSetMethodBuilder(string name, Type type,
+            TypeBuilder tb, MethodAttributes methodAttributes, FieldBuilder fieldBuilder)
+        {
+            var setMethodBuilder = tb.DefineMethod("set_" + name,
+                methodAttributes, null, new[] { type });
+            var il = setMethodBuilder.GetILGenerator();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Stfld, fieldBuilder);
+
+            il.Emit(OpCodes.Ret);
+            return setMethodBuilder;
+        }
+
+        private static void ValidateType(Type type)
+        {
+            if (!type.GetTypeInfo().IsInterface)
+                throw new ArgumentException($"Cannot create proxy instance of non-interface type {type}.", nameof(type));
+
+            foreach (var member in type.GetTypeInfo().GetMembers())
+            {
+                string errorMessage = null;
+                switch (member)
+                {
+                    case MethodInfo m when !m.Name.StartsWith("get_") && !m.Name.StartsWith("set_") && !m.Name.StartsWith("add_") && !m.Name.StartsWith("remove_"):
+                        errorMessage = $"Cannot create proxy {type} implementation: target interface cannot contain any methods. `{m}`";
+                        break;
+                    case EventInfo e:
+                        errorMessage = $"Cannot create proxy {type} implementation: target interface cannot contain any events. `{e}`";
+                        break;
+                    case PropertyInfo p when p.CanRead && p.GetGetMethod().GetParameters().Length > 0 || p.CanWrite && p.GetSetMethod().GetParameters().Length > 1:
+                        errorMessage = $"Cannot create proxy {type} implementation: target interface cannot contain any indexer properties. `{p.PropertyType.Name} this[{string.Join(", ", p.GetIndexParameters().Select(i => i.ParameterType.Name))}] {{ {(p.CanRead ? "get; " : "")} {(p.CanWrite ? "set; " : "")}}}`";
+                        break;
+                    case PropertyInfo p when !p.CanRead:
+                        errorMessage = $"Cannot create proxy {type} implementation: target interface cannot contain write-only methods. `{p} {{ set; }}`";
+                        break;
+                }
+                if (errorMessage != null)
+                    throw new ArgumentException(errorMessage, nameof(type));
+            }
+        }
+    }
+}

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -148,9 +148,9 @@ namespace RockLib.Configuration.ProxyFactory
             il.Emit(OpCodes.Ret);
         }
 
-        private static MethodBuilder GetGetMethodBuilder(string name, Type type, TypeBuilder tb, FieldBuilder fieldBuilder)
+        private static MethodBuilder GetGetMethodBuilder(string name, Type type, TypeBuilder typeBuilder, FieldBuilder fieldBuilder)
         {
-            var getMethodBuilder = tb.DefineMethod("get_" + name, _methodAttributes, type, Type.EmptyTypes);
+            var getMethodBuilder = typeBuilder.DefineMethod("get_" + name, _methodAttributes, type, Type.EmptyTypes);
             var il = getMethodBuilder.GetILGenerator();
 
             il.Emit(OpCodes.Ldarg_0);
@@ -160,9 +160,9 @@ namespace RockLib.Configuration.ProxyFactory
             return getMethodBuilder;
         }
 
-        private static MethodBuilder GetSetMethodBuilder(string name, Type type, TypeBuilder tb, FieldBuilder fieldBuilder)
+        private static MethodBuilder GetSetMethodBuilder(string name, Type type, TypeBuilder typeBuilder, FieldBuilder fieldBuilder)
         {
-            var setMethodBuilder = tb.DefineMethod("set_" + name, _methodAttributes, null, new[] { type });
+            var setMethodBuilder = typeBuilder.DefineMethod("set_" + name, _methodAttributes, null, new[] { type });
             var il = setMethodBuilder.GetILGenerator();
 
             il.Emit(OpCodes.Ldarg_0);

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -134,6 +134,9 @@ namespace RockLib.Configuration.ProxyFactory
                 MethodAttributes.Public, CallingConventions.Standard, readonlyFields.Select(f => f.FieldBuilder.FieldType).ToArray());
             var il = constructorBuilder.GetILGenerator();
 
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, typeof(object).GetTypeInfo().GetConstructors()[0]);
+
             for (int i = 0; i < readonlyFields.Count; i++)
             {
                 constructorBuilder.DefineParameter(i + 1, ParameterAttributes.None, readonlyFields[i].PropertyName);

--- a/RockLib.Configuration.ProxyFactory/Exceptions.cs
+++ b/RockLib.Configuration.ProxyFactory/Exceptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 
 namespace RockLib.Configuration.ProxyFactory

--- a/RockLib.Configuration.ProxyFactory/Exceptions.cs
+++ b/RockLib.Configuration.ProxyFactory/Exceptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+
+namespace RockLib.Configuration.ProxyFactory
+{
+    internal static class Exceptions
+    {
+        internal static ArgumentException CannotCreateProxyOfNonInterfaceType(Type type) =>
+            new ArgumentException($"Cannot create proxy instance of non-interface type {type}.", nameof(type));
+
+        internal static ArgumentException TargetInterfaceCannotHaveAnyMethods(Type type, MethodInfo m) =>
+            new ArgumentException($"Cannot create proxy {type} implementation: target interface cannot contain any methods. `{m}`", nameof(type));
+
+        internal static ArgumentException TargetInterfaceCannotHaveAnyEvents(Type type, EventInfo e) =>
+            new ArgumentException($"Cannot create proxy {type} implementation: target interface cannot contain any events. `{e}`", nameof(type));
+
+        internal static ArgumentException TargetInterfaceCannotHaveAnyIndexerProperties(Type type, PropertyInfo p) =>
+            new ArgumentException($"Cannot create proxy {type} implementation: target interface cannot contain any indexer properties. `{p.PropertyType.Name} this[{string.Join(", ", p.GetIndexParameters().Select(i => i.ParameterType.Name))}] {{ {(p.CanRead ? "get; " : "")} {(p.CanWrite ? "set; " : "")}}}`", nameof(type));
+
+        internal static ArgumentException TargetInterfaceCannotHaveAnyWriteOnlyProperties(Type type, PropertyInfo p) =>
+            new ArgumentException($"Cannot create proxy {type} implementation: target interface cannot contain write-only methods. `{p} {{ set; }}`", nameof(type));
+    }
+}

--- a/RockLib.Configuration.ProxyFactory/InternalsVisibleTo.cs
+++ b/RockLib.Configuration.ProxyFactory/InternalsVisibleTo.cs
@@ -1,0 +1,5 @@
+﻿#if DEBUG
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RockLib.Configuration.ProxyFactory.UnitTests")]
+#endif

--- a/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
+++ b/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
@@ -1,12 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net451;net47</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="0.0.1-alpha01" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' Or '$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' Or '$(TargetFramework)'=='net451'">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
+++ b/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="0.0.1-alpha01" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
+++ b/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
@@ -4,6 +4,19 @@
     <TargetFrameworks>netstandard1.6;netstandard2.0;net451;net47</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageId>RockLib.Configuration.ProxyFactory</PackageId>
+    <PackageVersion>0.0.1-alpha01</PackageVersion>
+    <Authors>Quicken Loans</Authors>
+    <Description>Creates proxy objects from interfaces using IConfiguration and IConfigurationSection objects.</Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <Copyright>Copyright 2017 (c) Quicken Loans Corporation. All rights reserved.</Copyright>
+    <PackageTags>Configuration Factory Proxy IConfiguration IConfigurationSection</PackageTags>
+    <Version>0.0.1-alpha01</Version>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="0.0.1-alpha01" />
   </ItemGroup>

--- a/RockLib.Configuration.sln
+++ b/RockLib.Configuration.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration", "RockLib.Configuration\RockLib.Configuration.csproj", "{33869C6F-C539-4FC7-89A6-114BFA3B05D8}"
 EndProject
@@ -22,6 +22,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.ObjectFactory", "RockLib.Configuration.ObjectFactory\RockLib.Configuration.ObjectFactory.csproj", "{1A866445-42C8-4A9B-82C5-D3B34EBF9147}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.ObjectFactory.UnitTests", "RockLib.Configuration.ObjectFactory.UnitTests\RockLib.Configuration.ObjectFactory.UnitTests.csproj", "{9DA180C2-E6BD-42E3-B157-D3164F6F269F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RockLib.Configuration.ProxyFactory", "RockLib.Configuration.ProxyFactory\RockLib.Configuration.ProxyFactory.csproj", "{668E5809-C181-4FFD-AF2B-29D342FD6909}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +71,10 @@ Global
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{668E5809-C181-4FFD-AF2B-29D342FD6909}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{668E5809-C181-4FFD-AF2B-29D342FD6909}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{668E5809-C181-4FFD-AF2B-29D342FD6909}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{668E5809-C181-4FFD-AF2B-29D342FD6909}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RockLib.Configuration.sln
+++ b/RockLib.Configuration.sln
@@ -23,7 +23,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.Objec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.ObjectFactory.UnitTests", "RockLib.Configuration.ObjectFactory.UnitTests\RockLib.Configuration.ObjectFactory.UnitTests.csproj", "{9DA180C2-E6BD-42E3-B157-D3164F6F269F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RockLib.Configuration.ProxyFactory", "RockLib.Configuration.ProxyFactory\RockLib.Configuration.ProxyFactory.csproj", "{668E5809-C181-4FFD-AF2B-29D342FD6909}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.ProxyFactory", "RockLib.Configuration.ProxyFactory\RockLib.Configuration.ProxyFactory.csproj", "{668E5809-C181-4FFD-AF2B-29D342FD6909}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.ProxyFactory.UnitTests", "RockLib.Configuration.ProxyFactory.UnitTests\RockLib.Configuration.ProxyFactory.UnitTests.csproj", "{0AF2FE77-91AA-43C5-AC7E-7E3E31627283}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -75,6 +77,10 @@ Global
 		{668E5809-C181-4FFD-AF2B-29D342FD6909}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{668E5809-C181-4FFD-AF2B-29D342FD6909}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{668E5809-C181-4FFD-AF2B-29D342FD6909}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AF2FE77-91AA-43C5-AC7E-7E3E31627283}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AF2FE77-91AA-43C5-AC7E-7E3E31627283}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AF2FE77-91AA-43C5-AC7E-7E3E31627283}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AF2FE77-91AA-43C5-AC7E-7E3E31627283}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/buildProxyFactoryNuget.bat
+++ b/build/buildProxyFactoryNuget.bat
@@ -1,0 +1,7 @@
+nuget restore -SolutionDirectory ../  ../RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
+
+msbuild /p:Configuration=Release /t:Clean ..\RockLib.Configuration.ProxyFactory\RockLib.Configuration.ProxyFactory.csproj
+
+msbuild /p:Configuration=Release /t:Rebuild ..\RockLib.Configuration.ProxyFactory\RockLib.Configuration.ProxyFactory.csproj
+
+msbuild /t:pack /p:PackageOutputPath=..\builtPackages  /p:Configuration=Release ..\RockLib.Configuration.ProxyFactory\RockLib.Configuration.ProxyFactory.csproj


### PR DESCRIPTION
This pull request adds a package containing two extension methods, `T CreateProxy<T>(this IConfiguration)` and `object CreateProxy(this IConfiguration, Type)`, where the generic `T` argument on the former and the `Type` parameter on the latter are interface types that have readable properties (and no methods, events, or write-only properties).

Given a config created from this json:

```json
{
  "foo": {
    "bar": 123,
    "baz": true
  }
}
```

And this interface:

```c#
public interface IFoo
{
    int Bar { get; }
    bool Baz { get; }
}
```

Then the following code results in an instance of the `IFoo` interface with its `Bar` and `Baz` properties each returning their expected values:

```c#
IConfiguration config = // TODO: get from json above
IConfigurationSection fooSection = config.GetSection("foo");
IFoo foo = fooSection.CreateProxy<IFoo>();
int bar = foo.Bar; // Should be 123
bool baz = foo.Baz; // Should be true
```

Behind the scenes, a proxy* type is created (and cached - it's expensive!) at runtime that implements the specified interface. That proxy type is then used as the target type for a call to `ConfigurationObjectFactory.Create`, passing in the `configuration` parameter.

\* Proxy, as in [Castle Dynamic Proxy](http://www.castleproject.org/projects/dynamicproxy/).