### PR TITLE
Support byte array constructor

### DIFF
--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -494,22 +494,6 @@ namespace Tests
         }
 
         [Fact]
-        public void CanBindToBindToByteArrayConstructorParameters()
-        {
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
-                    { "foo:key", "1J9Og/OaZKWdfdwM6jWMpvlr3q3o7r20xxFDN7TEj6s=" }
-                })
-                .Build();
-
-            var fooSection = config.GetSection("foo");
-            var foo = fooSection.Create<HasByteArrayConstructorParameter>();
-
-            Assert.Equal("1J9Og/OaZKWdfdwM6jWMpvlr3q3o7r20xxFDN7TEj6s=", foo.Key);
-        }
-
-        [Fact]
         public void CanBindToReadWriteConcreteProperties()
         {
             var guid = Guid.NewGuid();
@@ -963,6 +947,34 @@ namespace Tests
         }
 
         [Fact]
+        public void CanBindToByteCollectionConstructorParameters()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "foo:bar", "QmFy" },
+                    { "foo:baz", "QmF6" },
+                    { "foo:qux", "UXV6" },
+                    { "foo:garply", "R2FycGx5" },
+                    { "foo:grault", "R3JhdWx0" },
+                    { "foo:fred", "RnJlZA==" },
+                    { "foo:waldo", "V2FsZG8=" },
+                })
+                .Build();
+
+            var fooSection = config.GetSection("foo");
+            var foo = fooSection.Create<HasByteCollectionConstructorParameters>();
+
+            Assert.Equal("QmFy", foo.Bar);
+            Assert.Equal("QmF6", foo.Baz);
+            Assert.Equal("UXV6", foo.Qux);
+            Assert.Equal("R2FycGx5", foo.Garply);
+            Assert.Equal("R3JhdWx0", foo.Grault);
+            Assert.Equal("RnJlZA==", foo.Fred);
+            Assert.Equal("V2FsZG8=", foo.Waldo);
+        }
+
+        [Fact]
         public void CanBindToSimpleCollectionConstructorParametersWithSingleNonListItem()
         {
             var config = new ConfigurationBuilder()
@@ -1044,6 +1056,34 @@ namespace Tests
             Assert.Equal(2, foo.Waldo.Count);
             Assert.Equal(Encoding.UTF8, foo.Waldo[0].Baz);
             Assert.Equal(Encoding.ASCII, foo.Waldo[1].Baz);
+        }
+
+        [Fact]
+        public void CanBindToByteCollectionProperties()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "foo:bar", "QmFy" },
+                    { "foo:baz", "QmF6" },
+                    { "foo:qux", "UXV6" },
+                    { "foo:garply", "R2FycGx5" },
+                    { "foo:grault", "R3JhdWx0" },
+                    { "foo:fred", "RnJlZA==" },
+                    { "foo:waldo", "V2FsZG8=" },
+                })
+                .Build();
+
+            var fooSection = config.GetSection("foo");
+            var foo = fooSection.Create<HasByteCollectionProperties>();
+
+            Assert.Equal("QmFy", Convert.ToBase64String(foo.Bar));
+            Assert.Equal("QmF6", Convert.ToBase64String(foo.Baz.ToArray()));
+            Assert.Equal("UXV6", Convert.ToBase64String(foo.Qux.ToArray()));
+            Assert.Equal("R2FycGx5", Convert.ToBase64String(foo.Garply.ToArray()));
+            Assert.Equal("R3JhdWx0", Convert.ToBase64String(foo.Grault.ToArray()));
+            Assert.Equal("RnJlZA==", Convert.ToBase64String(foo.Fred.ToArray()));
+            Assert.Equal("V2FsZG8=", Convert.ToBase64String(foo.Waldo.ToArray()));
         }
 
         [Fact]
@@ -2058,6 +2098,34 @@ namespace Tests
         public IReadOnlyList<int> Waldo { get; }
     }
 
+    public class HasByteCollectionConstructorParameters
+    {
+        public HasByteCollectionConstructorParameters(
+            byte[] bar,
+            List<byte> baz,
+            IList<byte> qux,
+            ICollection<byte> garply,
+            IEnumerable<byte> grault,
+            IReadOnlyCollection<byte> fred,
+            IReadOnlyList<byte> waldo)
+        {
+            Bar = Convert.ToBase64String(bar);
+            Baz = Convert.ToBase64String(baz.ToArray());
+            Qux = Convert.ToBase64String(qux.ToArray());
+            Garply = Convert.ToBase64String(garply.ToArray());
+            Grault = Convert.ToBase64String(grault.ToArray());
+            Fred = Convert.ToBase64String(fred.ToArray());
+            Waldo = Convert.ToBase64String(waldo.ToArray());
+        }
+        public string Bar { get; }
+        public string Baz { get; }
+        public string Qux { get; }
+        public string Garply { get; }
+        public string Grault { get; }
+        public string Fred { get; }
+        public string Waldo { get; }
+    }
+
     public class HasConcreteReadWriteCollectionProperties
     {
         public HasSomething[] Bar { get; set; }
@@ -2067,6 +2135,17 @@ namespace Tests
         public IEnumerable<HasSomething> Grault { get; set; }
         public IReadOnlyCollection<HasSomething> Fred { get; set; }
         public IReadOnlyList<HasSomething> Waldo { get; set; }
+    }
+
+    public class HasByteCollectionProperties
+    {
+        public byte[] Bar { get; set; }
+        public List<byte> Baz { get; set; }
+        public IList<byte> Qux { get; set; }
+        public ICollection<byte> Garply { get; set; }
+        public IEnumerable<byte> Grault { get; set; }
+        public IReadOnlyCollection<byte> Fred { get; set; }
+        public IReadOnlyList<byte> Waldo { get; set; }
     }
 
     public class HasConcreteReadonlyCollectionProperties
@@ -2184,16 +2263,6 @@ namespace Tests
         public int Bar { get; }
         public DateTime Baz { get; }
         public bool Qux { get; }
-    }
-
-    public class HasByteArrayConstructorParameter
-    {
-        public HasByteArrayConstructorParameter(byte[] key)
-        {
-            Key = Convert.ToBase64String(key);
-        }
-
-        public string Key { get; set; }
     }
 
     public class HasReadWriteConcreteProperties

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -219,8 +219,15 @@ namespace RockLib.Configuration.ObjectFactory
             if (targetType.GetArrayRank() > 1) throw Exceptions.ArrayRankGreaterThanOneIsNotSupported(targetType);
 
             var elementType = targetType.GetElementType();
+            var isValueSection = IsValueSection(configuration);
+
             Array array;
-            if (IsValueSection(configuration) || !IsList(configuration))
+            if (isValueSection && elementType == typeof(byte))
+            {
+                var item = (string)configuration.Create(typeof(string), declaringType, memberName, valueConverters, defaultTypes);
+                array = Convert.FromBase64String(item);
+            }
+            else if (isValueSection || !IsList(configuration))
             {
                 var item = configuration.Create(elementType, declaringType, memberName, valueConverters, defaultTypes);
                 array = Array.CreateInstance(elementType, 1);

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -193,12 +193,12 @@ namespace RockLib.Configuration.ObjectFactory
             var i = 0;
             foreach (var child in configuration.GetChildren())
             {
-                if (child.Key == _typeKey)
+                if (child.Key.Equals(_typeKey, StringComparison.OrdinalIgnoreCase))
                 {
                     if (string.IsNullOrEmpty(child.Value)) return false;
                     typeFound = true;
                 }
-                else if (child.Key != _valueKey) return false;
+                else if (!child.Key.Equals(_valueKey, StringComparison.OrdinalIgnoreCase)) return false;
                 i++;
             }
             if (i == 1) return typeFound;

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -259,7 +259,16 @@ namespace RockLib.Configuration.ObjectFactory
             var listType = typeof(List<>).MakeGenericType(tType);
             var addMethod = GetListAddMethod(tType);
             var list = Activator.CreateInstance(listType);
-            if (IsValueSection(configuration) || !IsList(configuration))
+            var isValueSection = IsValueSection(configuration);
+
+            if (isValueSection && tType == typeof(byte))
+            {
+                var base64String = (string)configuration.Create(typeof(string), declaringType, memberName, valueConverters, defaultTypes);
+                var byteArray = Convert.FromBase64String(base64String);
+                foreach (var item in byteArray)
+                    addMethod.Invoke(list, new object[] { item });
+            }
+            else if (isValueSection || !IsList(configuration))
                 addMethod.Invoke(list, new[] {configuration.Create(tType, declaringType, memberName, valueConverters, defaultTypes)});
             else
                 foreach (var item in configuration.GetChildren().Select(child => child.Create(tType, declaringType, memberName, valueConverters, defaultTypes)))


### PR DESCRIPTION
This also allows for case-insensitive matching on the type and value properties for TypeSpecified configurations.