### PR TITLE
Loosening configuration interface constraints for easier consumption in dotnet core 2.0 asp setups

### DIFF
--- a/RockLib.Configuration.CustomConfigTests/ConfigTests.cs
+++ b/RockLib.Configuration.CustomConfigTests/ConfigTests.cs
@@ -6,11 +6,11 @@ namespace RockLib.Configuration.CustomConfigurationManagerTests
 {
     public class ConfigTests
     {
-        private static readonly IConfigurationRoot _configurationRoot;
+        private static readonly IConfiguration _configuration;
 
         static ConfigTests()
         {
-            _configurationRoot = new ConfigurationBuilder()
+            _configuration = new ConfigurationBuilder()
                     .AddInMemoryCollection(
                         new Dictionary<string, string>
                         {
@@ -19,7 +19,7 @@ namespace RockLib.Configuration.CustomConfigurationManagerTests
                         })
                     .Build();
 
-            Config.SetRoot(_configurationRoot);
+            Config.SetRoot(_configuration);
         }
 
         [Fact(DisplayName = "CustomConfigurationManagerTests: IsDefault is false when SetConfigurationRoot has been called.")]
@@ -31,7 +31,7 @@ namespace RockLib.Configuration.CustomConfigurationManagerTests
         [Fact(DisplayName = "CustomConfigurationManagerTests: The ConfigurationRoot property is the same instance passed to SetConfigurationRoot.")]
         public void TheCustomConfigurationRootIsUsed()
         {
-            Assert.Same(_configurationRoot, Config.Root);
+            Assert.Same(_configuration, Config.Root);
             Assert.Equal("Test", Config.AppSettings["Environment"]);
             Assert.Equal("200001", Config.AppSettings["ApplicationId"]);
         }

--- a/RockLib.Configuration/Config.cs
+++ b/RockLib.Configuration/Config.cs
@@ -6,11 +6,11 @@ using System.Collections.Generic;
 namespace RockLib.Configuration
 {
     /// <summary>
-    /// Defines a central location to store an instance of <see cref="IConfigurationRoot"/>.
+    /// Defines a central location to store an instance of <see cref="IConfiguration"/>.
     /// </summary>
     public static class Config
     {
-        private static readonly Semimutable<IConfigurationRoot> _root = new Semimutable<IConfigurationRoot>(() => GetDefaultRoot(null));
+        private static readonly Semimutable<IConfiguration> _root = new Semimutable<IConfiguration>(() => GetDefaultRoot(null));
 
         /// <summary>
         /// Gets an object that retrieves settings from the "AppSettings" section of the
@@ -20,7 +20,7 @@ namespace RockLib.Configuration
 
         /// <summary>
         /// Gets a value indicating whether the <see cref="Root"/> property is the default
-        /// instance of <see cref="IConfigurationRoot"/>.
+        /// instance of <see cref="IConfiguration"/>.
         /// </summary>
         public static bool IsDefault => _root.HasDefaultValue;
 
@@ -28,31 +28,31 @@ namespace RockLib.Configuration
         /// Gets a value indicating whether the <see cref="Root"/> property has been locked.
         /// <para>Tha value of this property is <c>false</c> before the <see cref="Root"/> property
         /// has been accessed and true after it has been accessed. When this property is true, any calls to the
-        /// <see cref="SetRoot(IConfigurationRoot)"/>,
-        /// <see cref="SetRoot(Func{IConfigurationRoot})"/>, or <see cref="ResetRoot"/>
+        /// <see cref="SetRoot(IConfiguration)"/>,
+        /// <see cref="SetRoot(Func{IConfiguration})"/>, or <see cref="ResetRoot"/>
         /// methods will result in an <see cref="InvalidOperationException"/>.</para>
         /// </summary>
         public static bool IsLocked => _root.IsLocked;
 
         /// <summary>
-        /// Gets the <see cref="IConfigurationRoot"/> associated with the <see cref="Config"/> class.
+        /// Gets the <see cref="IConfiguration"/> associated with the <see cref="Config"/> class.
         /// This property is guaranteed not to change.
         /// </summary>
-        public static IConfigurationRoot Root => _root.Value;
+        public static IConfiguration Root => _root.Value;
 
         /// <summary>
         /// Sets the value of the <see cref="Root"/> property to the specified
-        /// <see cref="IConfigurationRoot"/> instance.
+        /// <see cref="IConfiguration"/> instance.
         /// <para>NOTE: This method should only be called at the beginning of an application. Any calls to this method after
         /// the <see cref="Root"/> property has been accessed (i.e. when <see cref="IsLocked"/> is true) will
         /// result in an <see cref="InvalidOperationException"/> being thrown.</para>
         /// </summary>
         /// <param name="configurationRoot">
-        /// The instance of <see cref="IConfigurationRoot"/> to be used as the <see cref="Root"/> property.
+        /// The instance of <see cref="IConfiguration"/> to be used as the <see cref="Root"/> property.
         /// </param>
         /// <exception cref="ArgumentNullException">If the <paramref name="configurationRoot"/> parameter is null.</exception>
         /// <exception cref="InvalidOperationException">If the <see cref="IsLocked"/> property is true.</exception>
-        public static void SetRoot(IConfigurationRoot configurationRoot)
+        public static void SetRoot(IConfiguration configurationRoot)
         {
             if (configurationRoot == null) throw new ArgumentNullException(nameof(configurationRoot));
             SetRoot(() => configurationRoot);
@@ -66,12 +66,12 @@ namespace RockLib.Configuration
         /// result in an <see cref="InvalidOperationException"/> being thrown.</para>
         /// </summary>
         /// <param name="getRoot">
-        /// A function that returns the instance of <see cref="IConfigurationRoot"/> to be used as the <see cref="Root"/>
+        /// A function that returns the instance of <see cref="IConfiguration"/> to be used as the <see cref="Root"/>
         /// property. This function MUST NOT return null.
         /// </param>
         /// <exception cref="ArgumentNullException">If the <paramref name="getRoot"/> parameter is null.</exception>
         /// <exception cref="InvalidOperationException">If the <see cref="IsLocked"/> property is true.</exception>
-        public static void SetRoot(Func<IConfigurationRoot> getRoot)
+        public static void SetRoot(Func<IConfiguration> getRoot)
         {
             if (getRoot == null) throw new ArgumentNullException(nameof(getRoot));
             _root.SetValue(getRoot);
@@ -84,7 +84,7 @@ namespace RockLib.Configuration
         /// result in an <see cref="InvalidOperationException"/> being thrown.</para>
         /// </summary>
         /// <param name="additionalValues">When specified, these key/value pairs are applied to the resulting
-        /// instance of <see cref="IConfigurationRoot"/>.</param>
+        /// instance of <see cref="IConfiguration"/>.</param>
         /// <exception cref="InvalidOperationException">If the <see cref="IsLocked"/> property is true.</exception>
         public static void ResetRoot(IEnumerable<KeyValuePair<string, string>> additionalValues = null)
         {
@@ -94,7 +94,7 @@ namespace RockLib.Configuration
                 SetRoot(() => GetDefaultRoot(additionalValues));
         }
 
-        private static IConfigurationRoot GetDefaultRoot(IEnumerable<KeyValuePair<string, string>> additionalValues)
+        private static IConfiguration GetDefaultRoot(IEnumerable<KeyValuePair<string, string>> additionalValues)
         {
             var builder = new ConfigurationBuilder();
 


### PR DESCRIPTION
Default dotnet core 2 asp configuration template:
```
public IConfiguration Configuration { get; }

public Startup(IConfiguration configuration)
{
    Configuration = configuration;
}
```

In order to set the root for RockLib.Configuration, the configuration needs to be upcast.

By using `IConfiguration`,
```
Config.SetRoot((IConfigurationRoot)configuration);
```
would become
```
Config.SetRoot(configuration);
```