### PR TITLE
Improve list, enum support

### DIFF
--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -1214,6 +1214,26 @@ namespace Tests
         }
 
         [Fact]
+        public void FlagsEnumsSupportCSharpAndVisualBasicEnumDelimiters()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "foo:bar", "Garply, Grault, Corge" },
+                    { "foo:baz", "Garply | Grault | Corge" },
+                    { "foo:qux", "Garply Or Grault Or Corge" },
+                })
+                .Build();
+
+            var fooSection = config.GetSection("foo");
+            var foo = fooSection.Create<HasFlagsEnumProperties>();
+
+            Assert.Equal(Flags.Garply | Flags.Grault | Flags.Corge, foo.Bar);
+            Assert.Equal(Flags.Garply | Flags.Grault | Flags.Corge, foo.Baz);
+            Assert.Equal(Flags.Garply | Flags.Grault | Flags.Corge, foo.Qux);
+        }
+
+        [Fact]
         public void CanBindToReadonlyConcreteCollectionPropertiesWithSingleNonListItem()
         {
             var config = new ConfigurationBuilder()
@@ -2234,6 +2254,21 @@ namespace Tests
     {
         public List<HasSomething> Bar { get; } = new List<HasSomething>() { new HasSomething { Baz = Encoding.ASCII } };
         public HasSomethingCollection Baz { get; } = new HasSomethingCollection() { new HasSomething { Baz = Encoding.ASCII } };
+    }
+
+    public class HasFlagsEnumProperties
+    {
+        public Flags Bar { get; set; }
+        public Flags Baz { get; set; }
+        public Flags Qux { get; set; }
+    }
+
+    [Flags]
+    public enum Flags
+    {
+        Garply = 1,
+        Grault = 2,
+        Corge = 4
     }
 
     public class HasSomethingCollection : IList

--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using RockLib.Configuration.ObjectFactory;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -1152,6 +1153,35 @@ namespace Tests
         }
 
         [Fact]
+        public void CanBindToNonGenericListProperties()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "foo:bar:0:baz", "utf-8" },
+                    { "foo:bar:1:baz", "ascii" },
+                    { "foo:baz:0:baz", "utf-8" },
+                    { "foo:baz:1:baz", "ascii" },
+                    { "foo:qux:0:baz", "utf-8" },
+                    { "foo:qux:1:baz", "ascii" },
+                })
+                .Build();
+
+            var fooSection = config.GetSection("foo");
+            var foo = fooSection.Create<HasNonGenericCollectionProperties>();
+
+            Assert.Equal(2, foo.Bar.Count);
+            Assert.Equal(Encoding.UTF8, foo.Bar[0].Baz);
+            Assert.Equal(Encoding.ASCII, foo.Bar[1].Baz);
+            Assert.Equal(2, foo.Baz.Count);
+            Assert.Equal(Encoding.UTF8, foo.Baz[0].Baz);
+            Assert.Equal(Encoding.ASCII, foo.Baz[1].Baz);
+            Assert.Equal(2, foo.Qux.Count);
+            Assert.Equal(Encoding.UTF8, foo.Qux[0].Baz);
+            Assert.Equal(Encoding.ASCII, foo.Qux[1].Baz);
+        }
+
+        [Fact]
         public void CanBindToReadonlyConcreteCollectionPropertiesWithSingleNonListItem()
         {
             var config = new ConfigurationBuilder()
@@ -2154,6 +2184,107 @@ namespace Tests
         public List<HasSomething> Baz { get; } = new List<HasSomething>();
         public IList<HasSomething> Qux { get; } = new List<HasSomething>();
         public ICollection<HasSomething> Garply { get; } = new List<HasSomething>();
+    }
+
+    public class HasNonGenericCollectionProperties
+    {
+        public HasNonGenericCollectionProperties(HasSomethingCollection baz)
+        {
+            Baz = baz;
+        }
+
+        public HasSomethingCollection Bar { get; set; }
+        public HasSomethingCollection Baz { get; }
+        public HasSomethingCollection Qux { get; } = new HasSomethingCollection();
+    }
+
+    public class HasSomethingCollection : IList
+    {
+        private readonly List<HasSomething> _list = new List<HasSomething>();
+
+        object IList.this[int index] { get => this[index]; set => this[index] = (HasSomething)value; }
+
+        public HasSomething this[int index] { get => _list[index]; set => _list[index] = value; }
+
+        bool IList.IsFixedSize => ((IList)_list).IsFixedSize;
+
+        bool IList.IsReadOnly => ((IList)_list).IsReadOnly;
+
+        public int Count => _list.Count;
+
+        bool ICollection.IsSynchronized => ((IList)_list).IsSynchronized;
+
+        object ICollection.SyncRoot => ((IList)_list).SyncRoot;
+
+        int IList.Add(object value)
+        {
+            return Add((HasSomething)value);
+        }
+
+        public int Add(HasSomething value)
+        {
+            return ((IList)_list).Add(value);
+        }
+
+        public void Clear()
+        {
+            _list.Clear();
+        }
+
+        bool IList.Contains(object value)
+        {
+            return Contains((HasSomething)value);
+        }
+
+        public bool Contains(HasSomething value)
+        {
+            return _list.Contains(value);
+        }
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            ((IList)_list).CopyTo(array, index);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IList)_list).GetEnumerator();
+        }
+
+        int IList.IndexOf(object value)
+        {
+            return IndexOf((HasSomething)value);
+        }
+
+        public int IndexOf(HasSomething value)
+        {
+            return _list.IndexOf(value);
+        }
+
+        void IList.Insert(int index, object value)
+        {
+            Insert(index, (HasSomething)value);
+        }
+
+        public void Insert(int index, HasSomething value)
+        {
+            _list.Insert(index, value);
+        }
+
+        void IList.Remove(object value)
+        {
+            Remove((HasSomething)value);
+        }
+
+        public void Remove(HasSomething value)
+        {
+            _list.Remove(value);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _list.RemoveAt(index);
+        }
     }
 
     public class HasConcreteCollectionConstructorParameters

--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -1182,6 +1182,38 @@ namespace Tests
         }
 
         [Fact]
+        public void ReadonlyListPropertiesAreClearedBeforeAddingToThem()
+        {
+            // Verify that the object starts out with initial items.
+            var defaultFoo = new HasReadonlyListPropertiesWithInitialItems();
+
+            Assert.Equal(1, defaultFoo.Bar.Count);
+            Assert.Equal(Encoding.ASCII, defaultFoo.Bar[0].Baz);
+            Assert.Equal(1, defaultFoo.Baz.Count);
+            Assert.Equal(Encoding.ASCII, defaultFoo.Baz[0].Baz);
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "foo:bar:0:baz", "utf-8" },
+                    { "foo:bar:1:baz", "utf-32" },
+                    { "foo:baz:0:baz", "utf-8" },
+                    { "foo:baz:1:baz", "utf-32" },
+                })
+                .Build();
+
+            var fooSection = config.GetSection("foo");
+            var foo = fooSection.Create<HasReadonlyListPropertiesWithInitialItems>();
+
+            Assert.Equal(2, foo.Bar.Count);
+            Assert.Equal(Encoding.UTF8, foo.Bar[0].Baz);
+            Assert.Equal(Encoding.UTF32, foo.Bar[1].Baz);
+            Assert.Equal(2, foo.Baz.Count);
+            Assert.Equal(Encoding.UTF8, foo.Baz[0].Baz);
+            Assert.Equal(Encoding.UTF32, foo.Baz[1].Baz);
+        }
+
+        [Fact]
         public void CanBindToReadonlyConcreteCollectionPropertiesWithSingleNonListItem()
         {
             var config = new ConfigurationBuilder()
@@ -2196,6 +2228,12 @@ namespace Tests
         public HasSomethingCollection Bar { get; set; }
         public HasSomethingCollection Baz { get; }
         public HasSomethingCollection Qux { get; } = new HasSomethingCollection();
+    }
+
+    public class HasReadonlyListPropertiesWithInitialItems
+    {
+        public List<HasSomething> Bar { get; } = new List<HasSomething>() { new HasSomething { Baz = Encoding.ASCII } };
+        public HasSomethingCollection Baz { get; } = new HasSomethingCollection() { new HasSomething { Baz = Encoding.ASCII } };
     }
 
     public class HasSomethingCollection : IList

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -454,9 +454,17 @@ namespace RockLib.Configuration.ObjectFactory
             typeof(ICollection<>).MakeGenericType(tType)
                 .GetTypeInfo().GetMethod("Add");
 
+        private static MethodInfo GetListClearMethod(Type tType) =>
+            typeof(ICollection<>).MakeGenericType(tType)
+                .GetTypeInfo().GetMethod("Clear");
+
         private static MethodInfo GetDictionaryAddMethod(Type tValueType) =>
             typeof(ICollection<>).MakeGenericType(typeof(KeyValuePair<,>).MakeGenericType(typeof(string), tValueType))
                 .GetTypeInfo().GetMethod("Add");
+
+        private static MethodInfo GetDictionaryClearMethod(Type tValueType) =>
+            typeof(ICollection<>).MakeGenericType(typeof(KeyValuePair<,>).MakeGenericType(typeof(string), tValueType))
+                .GetTypeInfo().GetMethod("Clear");
 
         private class ObjectBuilder
         {
@@ -504,7 +512,9 @@ namespace RockLib.Configuration.ObjectFactory
                     if (list == null) return;
                     var tType = property.PropertyType.GetTypeInfo().GetGenericArguments()[0];
                     var addMethod = GetListAddMethod(tType);
+                    var clearMethod = GetListClearMethod(tType);
                     var propertyValue = section.Create(property.PropertyType, Type, property.Name, valueConverters, defaultTypes);
+                    clearMethod.Invoke(list, null);
                     foreach (var item in (IEnumerable)propertyValue)
                         addMethod.Invoke(list, new[] { item });
                 }
@@ -518,9 +528,11 @@ namespace RockLib.Configuration.ObjectFactory
                     if (dictionary == null) return;
                     var tValueType = property.PropertyType.GetTypeInfo().GetGenericArguments()[1];
                     var addMethod = GetDictionaryAddMethod(tValueType);
+                    var clearMethod = GetDictionaryClearMethod(tValueType);
                     var propertyValue = section.Create(property.PropertyType, Type, property.Name, valueConverters, defaultTypes);
+                    clearMethod.Invoke(dictionary, null);
                     foreach (var item in (IEnumerable)propertyValue)
-                        addMethod.Invoke(dictionary, new object[] { item });
+                        addMethod.Invoke(dictionary, new[] { item });
                 }
             }
 

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -142,7 +142,12 @@ namespace RockLib.Configuration.ObjectFactory
                     return Type.GetType(valueSection.Value, true, true);
                 var typeConverter = TypeDescriptor.GetConverter(targetType);
                 if (typeConverter.CanConvertFrom(typeof(string)))
-                    return typeConverter.ConvertFromInvariantString(valueSection.Value);
+                {
+                    var value = valueSection.Value;
+                    if (targetType.GetTypeInfo().IsEnum)
+                        value = value.Replace('|', ',');
+                    return typeConverter.ConvertFromInvariantString(value);
+                }
                 if (valueSection.Value == "")
                     return new ObjectBuilder(targetType, valueSection).Build(valueConverters, defaultTypes);
             }

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace RockLib.Configuration.ObjectFactory
 {
@@ -147,7 +148,10 @@ namespace RockLib.Configuration.ObjectFactory
                 {
                     var value = valueSection.Value;
                     if (targetType.GetTypeInfo().IsEnum)
-                        value = value.Replace('|', ',');
+                    {
+                        // Replace flags delimiters: c#'s "|" and vb's " Or ".
+                        value = Regex.Replace(value, @"\s*\|\s*|\s+[Oo][Rr]\s+", ", ");
+                    }
                     return typeConverter.ConvertFromInvariantString(value);
                 }
                 if (valueSection.Value == "")

--- a/RockLib.Configuration.ObjectFactory/Members.cs
+++ b/RockLib.Configuration.ObjectFactory/Members.cs
@@ -31,10 +31,11 @@ namespace RockLib.Configuration.ObjectFactory
         public static bool IsReadonlyList(this PropertyInfo p) =>
             p.CanRead
             && !p.CanWrite
-            && p.PropertyType.GetTypeInfo().IsGenericType
-            && (p.PropertyType.GetGenericTypeDefinition() == typeof(List<>)
-                || p.PropertyType.GetGenericTypeDefinition() == typeof(IList<>)
-                || p.PropertyType.GetGenericTypeDefinition() == typeof(ICollection<>));
+            && (p.PropertyType.GetTypeInfo().IsGenericType
+                && (p.PropertyType.GetGenericTypeDefinition() == typeof(List<>)
+                    || p.PropertyType.GetGenericTypeDefinition() == typeof(IList<>)
+                    || p.PropertyType.GetGenericTypeDefinition() == typeof(ICollection<>))
+                || p.PropertyType.IsNonGenericList());
 
         public static bool IsReadonlyDictionary(this PropertyInfo p) =>
             p.CanRead


### PR DESCRIPTION
- Clear readonly lists and dictionaries before adding to them
- Support the pipe character for delimiting flags enum values
- Add support for implementations of IList
  - As long as the implementation has a public Add, Contains, IndexOf, or method with a single non-object parameter, the type is supported.