### PR TITLE
Read-only, non-generic list - special case

### DIFF
--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -1229,7 +1229,9 @@ namespace Tests
             // The TraceSource.Listeners property is readonly, and the TraceListenerCollection class
             // does not have a default constructor, so this is a good example class to use for testing.
 
-            var traceSource = config.Create<TraceSource>();
+            var defaultTypes = new DefaultTypes { { typeof(TraceListener), typeof(DefaultTraceListener) } };
+
+            var traceSource = config.Create<TraceSource>(defaultTypes);
 
             Assert.Equal("source1", traceSource.Name);
             Assert.Equal(2, traceSource.Listeners.Count);

--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -3,6 +3,7 @@ using RockLib.Configuration.ObjectFactory;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Xunit;
@@ -1211,6 +1212,29 @@ namespace Tests
             Assert.Equal(2, foo.Baz.Count);
             Assert.Equal(Encoding.UTF8, foo.Baz[0].Baz);
             Assert.Equal(Encoding.UTF32, foo.Baz[1].Baz);
+        }
+
+        [Fact]
+        public void CanMapReadOnlyPropertiesOfTypeNonGenericIListImplementationWithoutDefaultConstructor()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "name", "source1" },
+                    { "listeners:0:name", "listener1" },
+                    { "listeners:1:name", "listener2" },
+                })
+                .Build();
+
+            // The TraceSource.Listeners property is readonly, and the TraceListenerCollection class
+            // does not have a default constructor, so this is a good example class to use for testing.
+
+            var traceSource = config.Create<TraceSource>();
+
+            Assert.Equal("source1", traceSource.Name);
+            Assert.Equal(2, traceSource.Listeners.Count);
+            Assert.Equal("listener1", traceSource.Listeners[0].Name);
+            Assert.Equal("listener2", traceSource.Listeners[1].Name);
         }
 
         [Fact]

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -105,7 +105,7 @@ namespace RockLib.Configuration.ObjectFactory
                 return BuildArray(configuration, targetType, declaringType, memberName, valueConverters, defaultTypes);
             if (IsGenericList(targetType))
                 return BuildGenericList(configuration, targetType, declaringType, memberName, valueConverters, defaultTypes);
-            if (IsNonGenericList(targetType))
+            if (IsNonGenericList(targetType, true))
                 return BuildNonGenericList(configuration, targetType, declaringType, memberName, valueConverters, defaultTypes);
             if (IsValueSection(configuration, out IConfigurationSection valueSection))
                 return ConvertToType(valueSection, targetType, declaringType, memberName, valueConverters, defaultTypes);
@@ -297,11 +297,13 @@ namespace RockLib.Configuration.ObjectFactory
             return list;
         }
 
-        internal static bool IsNonGenericList(this Type type)
+        internal static bool IsNonGenericList(this Type type, bool defaultConstructorRequired = false)
         {
             if (typeof(IList).GetTypeInfo().IsAssignableFrom(type))
             {
-                return type.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null
+                return
+                    (!defaultConstructorRequired
+                        || type.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null)
                     && GetNonGenericListItemType(type) != null;
             }
             return false;
@@ -566,7 +568,10 @@ namespace RockLib.Configuration.ObjectFactory
                         : null;
                     var addMethod = GetListAddMethod(tType);
                     var clearMethod = GetListClearMethod(tType);
-                    var propertyValue = section.Create(property.PropertyType, Type, property.Name, valueConverters, defaultTypes);
+                    var targetType = property.PropertyType;
+                    if (tType == null)
+                        targetType = typeof(List<>).MakeGenericType(GetNonGenericListItemType(targetType));
+                    var propertyValue = section.Create(targetType, Type, property.Name, valueConverters, defaultTypes);
                     clearMethod.Invoke(list, null);
                     foreach (var item in (IEnumerable)propertyValue)
                         addMethod.Invoke(list, new[] { item });

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -311,7 +311,7 @@ namespace RockLib.Configuration.ObjectFactory
         {
             var itemTypes =
                 nonGenericListType.GetTypeInfo().GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                    .Where(m => (m.Name == "Add" || m.Name == "Contains" || m.Name == "IndexOf" || m.Name == "Remove")
+                    .Where(m => m.Name == "Add"
                         && m.GetParameters().Length == 1
                         && m.GetParameters()[0].ParameterType != typeof(object))
                     .Select(m => m.GetParameters()[0].ParameterType)

--- a/RockLib.Configuration.ObjectFactory/Members.cs
+++ b/RockLib.Configuration.ObjectFactory/Members.cs
@@ -31,10 +31,10 @@ namespace RockLib.Configuration.ObjectFactory
         public static bool IsReadonlyList(this PropertyInfo p) =>
             p.CanRead
             && !p.CanWrite
-            && (p.PropertyType.GetTypeInfo().IsGenericType
-                && (p.PropertyType.GetGenericTypeDefinition() == typeof(List<>)
-                    || p.PropertyType.GetGenericTypeDefinition() == typeof(IList<>)
-                    || p.PropertyType.GetGenericTypeDefinition() == typeof(ICollection<>))
+            && ((p.PropertyType.GetTypeInfo().IsGenericType
+                    && (p.PropertyType.GetGenericTypeDefinition() == typeof(List<>)
+                        || p.PropertyType.GetGenericTypeDefinition() == typeof(IList<>)
+                        || p.PropertyType.GetGenericTypeDefinition() == typeof(ICollection<>)))
                 || p.PropertyType.IsNonGenericList());
 
         public static bool IsReadonlyDictionary(this PropertyInfo p) =>

--- a/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.csproj
+++ b/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.csproj
@@ -17,20 +17,8 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\RockLib.Configuration.ObjectFactory.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.6|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.6\RockLib.Configuration.ObjectFactory.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">
-    <DocumentationFile>bin\Release\net462\RockLib.Configuration.ObjectFactory.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net451|AnyCPU'">
-    <DocumentationFile>bin\Release\net451\RockLib.Configuration.ObjectFactory.xml</DocumentationFile>
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\RockLib.Configuration.ObjectFactory.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='net462'">


### PR DESCRIPTION
Support read-only properties with a non-generic list type that doesn't have a public, parameterless constructor.

The `TraceListenerCollection` type from the `TraceSource.Listeners` property is an example.