### PR TITLE
Fix bug where top-level object wouldn't get its default type applied

### DIFF
--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -2087,6 +2087,40 @@ namespace Tests
             Assert.Equal(Encoding.ASCII, foo.Baz["waldo"].Baz);
             Assert.IsType<HasSomething>(foo.Baz["waldo"]);
         }
+
+        [Fact]
+        public void UsesDefaultTypeAttributeForTopLevelType()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "fred", "123.45" },
+                })
+                .Build();
+
+            var instance = config.Create<IHasDefaultType>();
+
+            Assert.IsType<DefaultHasDefaultType>(instance);
+            Assert.Equal(123.45, ((DefaultHasDefaultType)instance).Fred);
+        }
+
+        [Fact]
+        public void UsesDefaultTypesObjectForTopLevelType()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "waldo", "123.45" },
+                })
+                .Build();
+
+            var defaults = new DefaultTypes().Add(typeof(IHasNoDefaultType), typeof(DefaultHasNoDefaultType));
+
+            var instance = config.Create<IHasNoDefaultType>(defaults);
+
+            Assert.IsType<DefaultHasNoDefaultType>(instance);
+            Assert.Equal(123.45, ((DefaultHasNoDefaultType)instance).Waldo);
+        }
     }
 
     public class HasSimpleReadWriteDictionaryProperties

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -400,9 +400,6 @@ namespace RockLib.Configuration.ObjectFactory
 
         private static bool TryGetDefaultType(IDefaultTypes defaultTypes, Type targetType, Type declaringType, string memberName, out Type defaultType)
         {
-            defaultType = null;
-            if (declaringType == null || memberName == null) return false;
-
             if (defaultTypes.TryGet(declaringType, memberName, out defaultType)) return true;
             if (defaultTypes.TryGet(targetType, out defaultType)) return true;
 

--- a/RockLib.Configuration.ObjectFactory/ValueConverters.cs
+++ b/RockLib.Configuration.ObjectFactory/ValueConverters.cs
@@ -46,7 +46,7 @@ namespace RockLib.Configuration.ObjectFactory
         /// </summary>
         /// <param name="targetType">A type that needs a default type.</param>
         /// <param name="convertFunc">A function that does the conversion from string to <typeparamref name="T"/>.</param>
-        /// <returns>This instance of <see cref="DefaultTypes"/>.</returns>
+        /// <returns>This instance of <see cref="ValueConverters"/>.</returns>
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="targetType"/> or <paramref name="convertFunc"/> is null.
         /// </exception>


### PR DESCRIPTION
Remove overzealous null check in `TryGetDefaultType` method.