### PR TITLE
Fix constructor selection bug

### DIFF
--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConstructorOrderInfoTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConstructorOrderInfoTests.cs
@@ -78,6 +78,8 @@ namespace Tests
         [InlineData(typeof(TwoParameters), typeof(OneParameter), -1, "bar", "baz")]
         [InlineData(typeof(TwoParameters), typeof(OneParameterOneOptionalParameter), 0, "bar", "baz")]
         [InlineData(typeof(OneParameterOneOptionalParameter), typeof(TwoParameters), 0, "bar", "baz")]
+        [InlineData(typeof(TwoParameters), typeof(ThreeOptionalParameters), 1, "bar")]
+        [InlineData(typeof(ThreeOptionalParameters), typeof(TwoParameters), -1, "bar")]
         public void CompareToReturnsTheCorrectValue(Type lhsConstructorType, Type rhsConstructorType, int expectedComparisonValue, params string[] resolvableMemberNames)
         {
             var lhsConstructor = lhsConstructorType.GetTypeInfo().GetConstructors()[0];
@@ -97,6 +99,7 @@ namespace Tests
         private class OneParameter { public OneParameter(int bar) { } }
         private class TwoParameters { public TwoParameters(int bar, int baz) { } }
         private class OneParameterOneOptionalParameter { public OneParameterOneOptionalParameter(int bar, int baz = -1) { } }
+        private class ThreeOptionalParameters { public ThreeOptionalParameters(int bar = -1, int baz = -1, int qux = -1) { } }
     }
 }
 #endif

--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConstructorOrderInfoTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConstructorOrderInfoTests.cs
@@ -28,16 +28,16 @@ namespace Tests
         }
 
         [Theory]
-        [InlineData(typeof(DefaultConstructor), 1)]
-        [InlineData(typeof(OneParameter), 1, "bar")]
-        [InlineData(typeof(OneParameter), 0)]
-        [InlineData(typeof(TwoParameters), 1, "bar", "baz")]
-        [InlineData(typeof(TwoParameters), 0.5, "bar")]
-        [InlineData(typeof(TwoParameters), 0)]
-        [InlineData(typeof(OneParameterOneOptionalParameter), 1, "bar", "baz")]
-        [InlineData(typeof(OneParameterOneOptionalParameter), 0.5, "bar")]
-        [InlineData(typeof(OneParameterOneOptionalParameter), 0)]
-        public void MatchedParametersRatioIsCorrect(Type type, double expectedMatchedParametersRatio, params string[] resolvableMemberNames)
+        [InlineData(typeof(DefaultConstructor), true)]
+        [InlineData(typeof(OneParameter), true, "bar")]
+        [InlineData(typeof(OneParameter), false)]
+        [InlineData(typeof(TwoParameters), true, "bar", "baz")]
+        [InlineData(typeof(TwoParameters), false, "bar")]
+        [InlineData(typeof(TwoParameters), false)]
+        [InlineData(typeof(OneParameterOneOptionalParameter), true, "bar", "baz")]
+        [InlineData(typeof(OneParameterOneOptionalParameter), false, "bar")]
+        [InlineData(typeof(OneParameterOneOptionalParameter), false)]
+        public void IsInvokableWithoutDefaultParametersIsCorrect(Type type, bool expectedIsInvokableWithoutDefaultParameters, params string[] resolvableMemberNames)
         {
             var constructor = type.GetTypeInfo().GetConstructors()[0];
             var members = resolvableMemberNames.ToDictionary(x => x, x => (IConfigurationSection)null);
@@ -45,20 +45,20 @@ namespace Tests
             var orderInfo = new ConstructorOrderInfo(constructor, members);
 
             Assert.Same(constructor, orderInfo.Constructor);
-            Assert.Equal(expectedMatchedParametersRatio, orderInfo.MatchedParametersRatio);
+            Assert.Equal(expectedIsInvokableWithoutDefaultParameters, orderInfo.IsInvokableWithoutDefaultParameters);
         }
 
         [Theory]
-        [InlineData(typeof(DefaultConstructor), 1)]
-        [InlineData(typeof(OneParameter), 1, "bar")]
-        [InlineData(typeof(OneParameter), 0)]
-        [InlineData(typeof(TwoParameters), 1, "bar", "baz")]
-        [InlineData(typeof(TwoParameters), 0.5, "bar")]
-        [InlineData(typeof(TwoParameters), 0)]
-        [InlineData(typeof(OneParameterOneOptionalParameter), 1, "bar", "baz")]
-        [InlineData(typeof(OneParameterOneOptionalParameter), 1, "bar")]
-        [InlineData(typeof(OneParameterOneOptionalParameter), 0.5)]
-        public void MatchedOrDefaultParametersRatioIsCorrect(Type type, double expectedMatchedOrDefaultParametersRatio, params string[] resolvableMemberNames)
+        [InlineData(typeof(DefaultConstructor), true)]
+        [InlineData(typeof(OneParameter), true, "bar")]
+        [InlineData(typeof(OneParameter), false)]
+        [InlineData(typeof(TwoParameters), true, "bar", "baz")]
+        [InlineData(typeof(TwoParameters), false, "bar")]
+        [InlineData(typeof(TwoParameters), false)]
+        [InlineData(typeof(OneParameterOneOptionalParameter), true, "bar", "baz")]
+        [InlineData(typeof(OneParameterOneOptionalParameter), true, "bar")]
+        [InlineData(typeof(OneParameterOneOptionalParameter), false)]
+        public void IsInvokableWithDefaultParametersIsCorrect(Type type, bool expectedIsInvokableWithDefaultParameters, params string[] resolvableMemberNames)
         {
             var constructor = type.GetTypeInfo().GetConstructors()[0];
             var members = resolvableMemberNames.ToDictionary(x => x, x => (IConfigurationSection)null);
@@ -66,7 +66,7 @@ namespace Tests
             var orderInfo = new ConstructorOrderInfo(constructor, members);
 
             Assert.Same(constructor, orderInfo.Constructor);
-            Assert.Equal(expectedMatchedOrDefaultParametersRatio, orderInfo.MatchedOrDefaultParametersRatio);
+            Assert.Equal(expectedIsInvokableWithDefaultParameters, orderInfo.IsInvokableWithDefaultParameters);
         }
 
         [Theory]

--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConstructorOrderInfoTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConstructorOrderInfoTests.cs
@@ -31,12 +31,20 @@ namespace Tests
         [InlineData(typeof(DefaultConstructor), true)]
         [InlineData(typeof(OneParameter), true, "bar")]
         [InlineData(typeof(OneParameter), false)]
+        [InlineData(typeof(OneOptionalParameter), true, "bar")]
+        [InlineData(typeof(OneOptionalParameter), false)]
         [InlineData(typeof(TwoParameters), true, "bar", "baz")]
         [InlineData(typeof(TwoParameters), false, "bar")]
+        [InlineData(typeof(TwoParameters), false, "baz")]
         [InlineData(typeof(TwoParameters), false)]
         [InlineData(typeof(OneParameterOneOptionalParameter), true, "bar", "baz")]
         [InlineData(typeof(OneParameterOneOptionalParameter), false, "bar")]
+        [InlineData(typeof(OneParameterOneOptionalParameter), false, "baz")]
         [InlineData(typeof(OneParameterOneOptionalParameter), false)]
+        [InlineData(typeof(TwoOptionalParameters), true, "bar", "baz")]
+        [InlineData(typeof(TwoOptionalParameters), false, "bar")]
+        [InlineData(typeof(TwoOptionalParameters), false, "baz")]
+        [InlineData(typeof(TwoOptionalParameters), false)]
         public void IsInvokableWithoutDefaultParametersIsCorrect(Type type, bool expectedIsInvokableWithoutDefaultParameters, params string[] resolvableMemberNames)
         {
             var constructor = type.GetTypeInfo().GetConstructors()[0];
@@ -52,12 +60,20 @@ namespace Tests
         [InlineData(typeof(DefaultConstructor), true)]
         [InlineData(typeof(OneParameter), true, "bar")]
         [InlineData(typeof(OneParameter), false)]
+        [InlineData(typeof(OneOptionalParameter), true, "bar")]
+        [InlineData(typeof(OneOptionalParameter), true)]
         [InlineData(typeof(TwoParameters), true, "bar", "baz")]
         [InlineData(typeof(TwoParameters), false, "bar")]
+        [InlineData(typeof(TwoParameters), false, "baz")]
         [InlineData(typeof(TwoParameters), false)]
         [InlineData(typeof(OneParameterOneOptionalParameter), true, "bar", "baz")]
         [InlineData(typeof(OneParameterOneOptionalParameter), true, "bar")]
+        [InlineData(typeof(OneParameterOneOptionalParameter), false, "baz")]
         [InlineData(typeof(OneParameterOneOptionalParameter), false)]
+        [InlineData(typeof(TwoOptionalParameters), true, "bar", "baz")]
+        [InlineData(typeof(TwoOptionalParameters), true, "bar")]
+        [InlineData(typeof(TwoOptionalParameters), true, "baz")]
+        [InlineData(typeof(TwoOptionalParameters), true)]
         public void IsInvokableWithDefaultParametersIsCorrect(Type type, bool expectedIsInvokableWithDefaultParameters, params string[] resolvableMemberNames)
         {
             var constructor = type.GetTypeInfo().GetConstructors()[0];
@@ -97,8 +113,10 @@ namespace Tests
 
         private class DefaultConstructor { }
         private class OneParameter { public OneParameter(int bar) { } }
+        private class OneOptionalParameter { public OneOptionalParameter(int bar = -1) { } }
         private class TwoParameters { public TwoParameters(int bar, int baz) { } }
         private class OneParameterOneOptionalParameter { public OneParameterOneOptionalParameter(int bar, int baz = -1) { } }
+        private class TwoOptionalParameters { public TwoOptionalParameters(int bar = -1, int baz = -1) { } }
         private class ThreeOptionalParameters { public ThreeOptionalParameters(int bar = -1, int baz = -1, int qux = -1) { } }
     }
 }

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -601,7 +601,7 @@ namespace RockLib.Configuration.ObjectFactory
                     .ToList();
                 if (orderedConstructors.Count > 1 && orderedConstructors[0].CompareTo(orderedConstructors[1]) == 0)
                     throw Exceptions.AmbiguousConstructors(Type);
-                if (orderedConstructors[0].MatchedOrDefaultParametersRatio < 1)
+                if (!orderedConstructors[0].IsInvokableWithDefaultParameters)
                     throw Exceptions.MissingRequiredConstructorParameters(Configuration, orderedConstructors[0]);
                 return orderedConstructors[0].Constructor;
             }

--- a/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
+++ b/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
@@ -15,30 +15,30 @@ namespace RockLib.Configuration.ObjectFactory
             TotalParameters = parameters.Length;
             if (TotalParameters == 0)
             {
-                MatchedParametersRatio = 1;
-                MatchedOrDefaultParametersRatio = 1;
+                IsInvokableWithoutDefaultParameters = true;
+                IsInvokableWithDefaultParameters = true;
                 MissingParameterNames = Enumerable.Empty<string>();
             }
             else
             {
-                MatchedParametersRatio = parameters.Count(p => availableMembers.ContainsKey(p.Name)) / (double)TotalParameters;
-                MatchedOrDefaultParametersRatio = parameters.Count(p => availableMembers.ContainsKey(p.Name) || p.HasDefaultValue) / (double)TotalParameters;
+                IsInvokableWithoutDefaultParameters = parameters.Count(p => availableMembers.ContainsKey(p.Name)) == TotalParameters;
+                IsInvokableWithDefaultParameters = parameters.Count(p => availableMembers.ContainsKey(p.Name) || p.HasDefaultValue) == TotalParameters;
                 MissingParameterNames = parameters.Where(p => !availableMembers.ContainsKey(p.Name) && !p.HasDefaultValue).Select(p => p.Name);
             }
         }
 
         public ConstructorInfo Constructor { get; }
-        public double MatchedParametersRatio { get; }
-        public double MatchedOrDefaultParametersRatio { get; }
+        public bool IsInvokableWithoutDefaultParameters { get;  }
+        public bool IsInvokableWithDefaultParameters { get; }
         public int TotalParameters { get; }
         public IEnumerable<string> MissingParameterNames { get; }
 
         public int CompareTo(ConstructorOrderInfo other)
         {
-            if (MatchedParametersRatio > other.MatchedParametersRatio) return -1;
-            if (MatchedParametersRatio < other.MatchedParametersRatio) return 1;
-            if (MatchedOrDefaultParametersRatio > other.MatchedOrDefaultParametersRatio) return -1;
-            if (MatchedOrDefaultParametersRatio < other.MatchedOrDefaultParametersRatio) return 1;
+            if (IsInvokableWithoutDefaultParameters && !other.IsInvokableWithoutDefaultParameters) return -1;
+            if (!IsInvokableWithoutDefaultParameters && other.IsInvokableWithoutDefaultParameters) return 1;
+            if (IsInvokableWithDefaultParameters && !other.IsInvokableWithDefaultParameters) return -1;
+            if (!IsInvokableWithDefaultParameters && other.IsInvokableWithDefaultParameters) return 1;
             if (TotalParameters > other.TotalParameters) return -1;
             if (TotalParameters < other.TotalParameters) return 1;
             return 0;


### PR DESCRIPTION
The bug happens when there are two constructors and the first has more than one parameter with none optional and second has the same parameters as the first plus an additional with all parameters optional. When the available configuration fields consists of a single item that matches one of the shared parameters, then the illegal first constructor is selected, when the legal second constructor should be selected.

The fix involves changing some details about how constructors are compared to one another during ordering.