### PR TITLE
Improvements around when *not* to reload

### DIFF
--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigReloadingProxyFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigReloadingProxyFactoryTests.cs
@@ -191,7 +191,7 @@ namespace Tests
         [Fact]
         public void ReloadMethodForcesTheUnderlyingObjectToReload()
         {
-            IConfigurationRoot configuration = GetConfig(new KeyValuePair<string, string>("foo:reloadOnChange", "false"));
+            IConfigurationRoot configuration = GetConfig();
 
             var foo = (ConfigReloadingProxy<IFoo>)configuration.GetSection("foo").CreateReloadingProxy<IFoo>();
 
@@ -202,6 +202,16 @@ namespace Tests
             var reloadedObject = foo.Object;
 
             Assert.NotSame(initialObject, reloadedObject);
+        }
+
+        [Fact]
+        public void AnInitialReloadOnChangeOfFalseDoesNotCreateProxy()
+        {
+            IConfigurationRoot configuration = GetConfig(new KeyValuePair<string, string>("foo:reloadOnChange", "false"));
+
+            var foo = configuration.GetSection("foo").CreateReloadingProxy<IFoo>();
+
+            Assert.IsType<Foo>(foo);
         }
 
         [Fact]

--- a/RockLib.Configuration.ObjectFactory/ConfigReloadingProxyFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigReloadingProxyFactory.cs
@@ -83,6 +83,10 @@ namespace RockLib.Configuration.ObjectFactory
             if (typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(interfaceType))
                 throw new ArgumentException($"Interfaces that inherit from IEnumerable are not suported: '{interfaceType.FullName}'", nameof(interfaceType));
 
+            if (!string.IsNullOrEmpty(configuration[ConfigurationObjectFactory.TypeKey])
+                && string.Equals(configuration[ConfigurationObjectFactory.ReloadOnChangeKey], "false", StringComparison.OrdinalIgnoreCase))
+                return configuration.BuildTypeSpecifiedObject(interfaceType, declaringType, memberName, valueConverters ?? new ValueConverters(), defaultTypes ?? new DefaultTypes());
+
             var createReloadingProxy = _proxyFactories.GetOrAdd(interfaceType, CreateProxyTypeFactoryMethod);
             return createReloadingProxy.Invoke(configuration, defaultTypes, valueConverters, declaringType, memberName);
         }

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -240,14 +240,15 @@ namespace RockLib.Configuration.ObjectFactory
                     if (string.IsNullOrEmpty(child.Value)) return false;
                     typeFound = true;
                 }
+                else if (child.Key.Equals(ReloadOnChangeKey, StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(child.Value, "false", StringComparison.OrdinalIgnoreCase)) return false;
                 else if (!child.Key.Equals(ValueKey, StringComparison.OrdinalIgnoreCase)) return false;
                 i++;
             }
-            if (i == 1) return typeFound;
-            return i == 2;
+            return typeFound && i >= 1 && i <= 3;
         }
 
-        private static object BuildTypeSpecifiedObject(IConfiguration configuration, Type targetType, Type declaringType, string memberName, ValueConverters valueConverters, DefaultTypes defaultTypes)
+        internal static object BuildTypeSpecifiedObject(this IConfiguration configuration, Type targetType, Type declaringType, string memberName, ValueConverters valueConverters, DefaultTypes defaultTypes)
         {
             var typeSection = configuration.GetSection(TypeKey);
             var specifiedType = Type.GetType(typeSection.Value, throwOnError: true);


### PR DESCRIPTION
- A reloading proxy doesn't reload if its configuration section hasn't changed.
- If a section has `reloadOnChange` explicitly configured to be `false`, then the `CreateReloadingProxy` extension method returns a regular object, not a config reloading proxy object.
- A small expansion of the definition of what a "type-specified object" is to allow a `reloadOnChange` of `false`.