### PR TITLE
Fix object convert bug

### DIFF
--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -2226,6 +2226,23 @@ namespace Tests
             Assert.Equal(123, baz["c"]);
             Assert.Equal(456, baz["d"]);
         }
+
+        [Fact]
+        public void ObjectFieldsWithDirectConfigurationValuesAreSupported()
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["foo:bar"] = "abc",
+                ["foo:baz:a"] = "123",
+                ["foo:baz:b"] = "xyz"
+            }).Build();
+
+            var foo = config.GetSection("foo").Create<HasObjectMembers>();
+
+            Assert.Equal("abc", foo.Bar);
+            Assert.Equal("123", foo.Baz["a"]);
+            Assert.Equal("xyz", foo.Baz["b"]);
+        }
     }
 
     public class HasSimpleReadWriteDictionaryProperties
@@ -2980,6 +2997,18 @@ namespace Tests
 
         public object Bar { get; }
         public object Baz { get; }
+    }
+
+    public class HasObjectMembers
+    {
+        public HasObjectMembers(object bar, Dictionary<string, object> baz)
+        {
+            Bar = bar;
+            Baz = baz;
+        }
+
+        public object Bar { get; }
+        public Dictionary<string, object> Baz { get; }
     }
 }
 

--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -142,6 +142,8 @@ namespace RockLib.Configuration.ObjectFactory
             {
                 if (convert != null)
                     return convert(valueSection.Value) ?? throw Exceptions.ResultCannotBeNull(targetType, declaringType, memberName);
+                if (targetType.GetTypeInfo().IsAssignableFrom(typeof(string)))
+                    return valueSection.Value;
                 if (targetType == typeof(Encoding))
                     return Encoding.GetEncoding(valueSection.Value);
                 if (targetType == typeof(Type))


### PR DESCRIPTION
The bug occurred when a member was of type object and its configuration had a direct value for it. The fix is in the convert method - if the target type is `object`, just return the configuration value.