### PR TITLE
Add [AlternateName] attribute

### DIFF
--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -2422,6 +2422,102 @@ namespace Tests
             Assert.Equal("123", foo.Baz["a"]);
             Assert.Equal("xyz", foo.Baz["b"]);
         }
+
+        [Theory]
+        [InlineData(typeof(HasMembersDecoratedWithSingleAlternateNameAttribute), "foo")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleAlternateNameAttribute), "foo1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "foo")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "foo1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "foo2")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute), "foo")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute), "foo1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "foo")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "foo1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "foo2")]
+        public void Constructors(Type type, string configurationKey)
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
+            {
+                [configurationKey] = "abc"
+            }).Build();
+
+            var item = (IHasMembers)config.Create(type);
+
+            Assert.Equal("abc", item.Foo);
+        }
+
+        [Theory]
+        [InlineData(typeof(HasMembersDecoratedWithSingleAlternateNameAttribute), "bar")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleAlternateNameAttribute), "bar1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "bar")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "bar1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "bar2")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute), "bar")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute), "bar1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "bar")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "bar1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "bar2")]
+        public void ReadWriteProperties(Type type, string configurationKey)
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
+            {
+                [configurationKey] = "abc"
+            }).Build();
+
+            var item = (IHasMembers)config.Create(type);
+
+            Assert.Equal("abc", item.Bar);
+        }
+
+        [Theory]
+        [InlineData(typeof(HasMembersDecoratedWithSingleAlternateNameAttribute), "baz")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleAlternateNameAttribute), "baz1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "baz")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "baz1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "baz2")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute), "baz")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute), "baz1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "baz")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "baz1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "baz2")]
+        public void ReadonlyListProperties(Type type, string configurationKey)
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
+            {
+                [configurationKey] = "abc"
+            }).Build();
+
+            var item = (IHasMembers)config.Create(type);
+
+            Assert.Single(item.Baz);
+            Assert.Equal("abc", item.Baz[0]);
+        }
+
+        [Theory]
+        [InlineData(typeof(HasMembersDecoratedWithSingleAlternateNameAttribute), "qux")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleAlternateNameAttribute), "qux1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "qux")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "qux1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleAlternateNameAttributes), "qux2")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute), "qux")]
+        [InlineData(typeof(HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute), "qux1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "qux")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "qux1")]
+        [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "qux2")]
+        public void ReadonlyDictionaryProperties(Type type, string configurationKey)
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
+            {
+                [$"{configurationKey}:garply"] = "abc"
+            }).Build();
+
+            var item = (IHasMembers)config.Create(type);
+
+            Assert.Single(item.Qux);
+            var dictionaryItem = item.Qux.Single();
+            Assert.Equal("garply", dictionaryItem.Key);
+            Assert.Equal("abc", dictionaryItem.Value);
+        }
     }
 
     public class HasSimpleReadWriteDictionaryProperties
@@ -3165,6 +3261,50 @@ namespace Tests
         private static double ConvertBaz(string value) => double.Parse(value) * 11;
     }
 
+    public interface IHasMembers
+    {
+        string Foo { get; }
+        string Bar { get; }
+        List<string> Baz { get; }
+        Dictionary<string, string> Qux { get; }
+    }
+
+    public class HasMembersDecoratedWithSingleAlternateNameAttribute : IHasMembers
+    {
+        public HasMembersDecoratedWithSingleAlternateNameAttribute([AlternateName("foo1")] string foo = null) => Foo = foo;
+        public string Foo { get; }
+        [AlternateName("bar1")] public string Bar { get; set; }
+        [AlternateName("baz1")] public List<string> Baz { get; } = new List<string>();
+        [AlternateName("qux1")] public Dictionary<string, string> Qux { get; } = new Dictionary<string, string>();
+    }
+
+    public class HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute : IHasMembers
+    {
+        public HasMembersDecoratedWithSingleLocallyDefinedAlternateNameAttribute([LocallyDefined.AlternateName("foo1")] string foo = null) => Foo = foo;
+        public string Foo { get; }
+        [LocallyDefined.AlternateName("bar1")] public string Bar { get; set; }
+        [LocallyDefined.AlternateName("baz1")] public List<string> Baz { get; } = new List<string>();
+        [LocallyDefined.AlternateName("qux1")] public Dictionary<string, string> Qux { get; } = new Dictionary<string, string>();
+    }
+
+    public class HasMembersDecoratedWithMultipleAlternateNameAttributes : IHasMembers
+    {
+        public HasMembersDecoratedWithMultipleAlternateNameAttributes([AlternateName("foo1"), AlternateName("foo2")] string foo = null) => Foo = foo;
+        public string Foo { get; }
+        [AlternateName("bar1"), AlternateName("bar2")] public string Bar { get; set; }
+        [AlternateName("baz1"), AlternateName("baz2")] public List<string> Baz { get; } = new List<string>();
+        [AlternateName("qux1"), AlternateName("qux2")] public Dictionary<string, string> Qux { get; } = new Dictionary<string, string>();
+    }
+
+    public class HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes : IHasMembers
+    {
+        public HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes([LocallyDefined.AlternateName("foo1"), LocallyDefined.AlternateName("foo2")] string foo = null) => Foo = foo;
+        public string Foo { get; }
+        [LocallyDefined.AlternateName("bar1"), LocallyDefined.AlternateName("bar2")] public string Bar { get; set; }
+        [LocallyDefined.AlternateName("baz1"), LocallyDefined.AlternateName("baz2")] public List<string> Baz { get; } = new List<string>();
+        [LocallyDefined.AlternateName("qux1"), LocallyDefined.AlternateName("qux2")] public Dictionary<string, string> Qux { get; } = new Dictionary<string, string>();
+    }
+
     public class HasObjectMembersWithDefaultTypeOfStringDictionary
     {
         public HasObjectMembersWithDefaultTypeOfStringDictionary([DefaultType(typeof(Dictionary<string, string>))] object bar,
@@ -3203,5 +3343,12 @@ namespace LocallyDefined
     {
         public ConvertMethodAttribute(string convertMethodName) => ConvertMethodName = convertMethodName;
         public string ConvertMethodName { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = true)]
+    internal class AlternateNameAttribute : Attribute
+    {
+        public AlternateNameAttribute(string name) => Name = name;
+        public string Name { get; }
     }
 }

--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConfigurationObjectFactoryTests.cs
@@ -2434,7 +2434,7 @@ namespace Tests
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "foo")]
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "foo1")]
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "foo2")]
-        public void Constructors(Type type, string configurationKey)
+        public void ConstructorsUseAlternateNameAttribute(Type type, string configurationKey)
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
             {
@@ -2457,7 +2457,7 @@ namespace Tests
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "bar")]
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "bar1")]
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "bar2")]
-        public void ReadWriteProperties(Type type, string configurationKey)
+        public void ReadWritePropertiesUseAlternateNameAttribute(Type type, string configurationKey)
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
             {
@@ -2480,7 +2480,7 @@ namespace Tests
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "baz")]
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "baz1")]
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "baz2")]
-        public void ReadonlyListProperties(Type type, string configurationKey)
+        public void ReadonlyListPropertiesUseAlternateNameAttribute(Type type, string configurationKey)
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
             {
@@ -2504,7 +2504,7 @@ namespace Tests
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "qux")]
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "qux1")]
         [InlineData(typeof(HasMembersDecoratedWithMultipleLocallyDefinedAlternateNameAttributes), "qux2")]
-        public void ReadonlyDictionaryProperties(Type type, string configurationKey)
+        public void ReadonlyDictionaryPropertiesUseAlternateNameAttribute(Type type, string configurationKey)
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
             {

--- a/RockLib.Configuration.ObjectFactory.UnitTests/ConstructorOrderInfoTests.cs
+++ b/RockLib.Configuration.ObjectFactory.UnitTests/ConstructorOrderInfoTests.cs
@@ -114,6 +114,25 @@ namespace Tests
             Assert.Equal(expectedComparisonValue, actual);
         }
 
+        [Theory]
+        [InlineData(typeof(OneAlternateName), "foo")]
+        [InlineData(typeof(OneAlternateName), "bar")]
+        [InlineData(typeof(MultipleAlternateNames), "foo")]
+        [InlineData(typeof(MultipleAlternateNames), "bar")]
+        [InlineData(typeof(MultipleAlternateNames), "baz")]
+        public void AlternateNameIsUsed(Type type, string configurationMemberName)
+        {
+            var constructor = type.GetConstructors()[0];
+            var members = new Dictionary<string, IConfigurationSection>() { { configurationMemberName, null } };
+
+            var orderInfo = new ConstructorOrderInfo(constructor, members, Resolver.Empty);
+
+            Assert.True(orderInfo.IsInvokableWithoutDefaultParameters);
+            Assert.True(orderInfo.IsInvokableWithDefaultParameters);
+            Assert.Equal(1, orderInfo.MatchedParameters);
+            Assert.Empty(orderInfo.MissingParameterNames);
+        }
+
         private class DefaultConstructor { }
         private class OneParameter { public OneParameter(int bar) { } }
         private class OneOptionalParameter { public OneOptionalParameter(int bar = -1) { } }
@@ -122,6 +141,18 @@ namespace Tests
         private class TwoOptionalParameters { public TwoOptionalParameters(int bar = -1, int baz = -1) { } }
         private class ThreeOptionalParameters { public ThreeOptionalParameters(int bar = -1, int baz = -1, int qux = -1) { } }
         private class ThreeParametersOneRequired { public ThreeParametersOneRequired(int foo, int baz = -1, int qux = -1) { } }
+
+        private class OneAlternateName
+        {
+            public OneAlternateName([AlternateName("bar")] int foo) => Foo = foo;
+            public int Foo { get; }
+        }
+
+        private class MultipleAlternateNames
+        {
+            public MultipleAlternateNames([AlternateName("bar"), AlternateName("baz")] int foo) => Foo = foo;
+            public int Foo { get; }
+        }
     }
 }
 #endif

--- a/RockLib.Configuration.ObjectFactory/AlternateNameAttribute.cs
+++ b/RockLib.Configuration.ObjectFactory/AlternateNameAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace RockLib.Configuration.ObjectFactory
+{
+    /// <summary>
+    /// Defines an alternate name for a constructor parameter or property.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = true)]
+    public class AlternateNameAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AlternateNameAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The alternate name.</param>
+        public AlternateNameAttribute(string name) => Name = name ?? throw new ArgumentNullException(nameof(name));
+
+        /// <summary>
+        /// Gets the alternate name.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
+++ b/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
@@ -23,7 +23,7 @@ namespace RockLib.Configuration.ObjectFactory
             else
             {
                 bool HasAvailableValue(ParameterInfo p) =>
-                    availableMembers.ContainsKey(p.Name) || resolver.CanResolve(p);
+                    p.GetNames().Any(name => availableMembers.ContainsKey(name)) || resolver.CanResolve(p);
 
                 IsInvokableWithoutDefaultParameters = parameters.Count(HasAvailableValue) == TotalParameters;
                 IsInvokableWithDefaultParameters = parameters.Count(p => HasAvailableValue(p) || p.HasDefaultValue) == TotalParameters;

--- a/RockLib.Configuration.ObjectFactory/ValueConverters.cs
+++ b/RockLib.Configuration.ObjectFactory/ValueConverters.cs
@@ -40,11 +40,11 @@ namespace RockLib.Configuration.ObjectFactory
 
         /// <summary>
         /// Configures a converter for the specified target type. Use this method when you want all
-        /// members (properties or constructor parameters) of the target type to use the same converter.
-        /// If you need different members of a target type to each use a different converter, use
+        /// instances of the target type to use the same converter. If you need instances of the target
+        /// type to each use a different converter depending on which member is being populated, use
         /// the other <see cref="Add{T}(Type, string, Func{string, T})"/> method.
         /// </summary>
-        /// <param name="targetType">A type that needs a default type.</param>
+        /// <param name="targetType">A type that needs a converter.</param>
         /// <param name="convertFunc">A function that does the conversion from string to <typeparamref name="T"/>.</param>
         /// <returns>This instance of <see cref="ValueConverters"/>.</returns>
         /// <exception cref="ArgumentNullException">


### PR DESCRIPTION
This allows users to specify one or more alternate names for a constructor parameter / writable property.