### PR TITLE
Handle custom implementations of IEnumerable

### DIFF
--- a/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigurationObjectFactory.cs
@@ -527,7 +527,7 @@ namespace RockLib.Configuration.ObjectFactory
                 throw Exceptions.CannotCreateAbstractType(configuration, targetType);
             if (targetType == typeof(object))
                 throw Exceptions.CannotCreateObjectType;
-            if (typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(targetType))
+            if (typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(targetType) && targetType.FullName.StartsWith("System.Collections."))
                 throw Exceptions.UnsupportedCollectionType(targetType);
             if (IsList(configuration, includeEmptyList: false))
                 throw Exceptions.ConfigurationIsAList(configuration, targetType);

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigurationObjectFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigurationObjectFactoryTests.cs
@@ -13,6 +13,21 @@ namespace Tests
     public class ConfigurationObjectFactoryTests
     {
         [Fact]
+        public void SupportsCustomTypeImplementingIEnumerable()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "foo:bar:baz", "123.45" },
+                })
+                .Build();
+
+            var fooSection = config.GetSection("foo");
+            var foo = fooSection.Create<CustomEnumerablePropertyClass>();
+            Assert.Equal(123.45M, foo.Bar.Baz);
+        }
+
+        [Fact]
         public void SupportsMembersOfTypeFuncOfT()
         {
             var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string> {
@@ -3356,6 +3371,20 @@ namespace Tests
 
         public object Bar { get; }
         public Dictionary<string, object> Baz { get; }
+    }
+
+    public class CustomEnumerablePropertyClass
+    {
+        public CustomEnumerable Bar { get; set; }
+    }
+
+    public class CustomEnumerable : IEnumerable<char>
+    {
+        public decimal Baz { get; set; }
+
+        public IEnumerator<char> GetEnumerator() => Baz.ToString().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => Baz.ToString().GetEnumerator();
     }
 }
 


### PR DESCRIPTION
Only implementations of `IEnumerable` in the System.Collections namespace are disallowed. Implementations of `IEnumerable` *not* in this namespace are treated as regular objects.