### PR TITLE
Fix ambiguous constructor issue

### DIFF
--- a/RockLib.Configuration.ObjectFactory/CHANGELOG.md
+++ b/RockLib.Configuration.ObjectFactory/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Changed
+
+- Fixes ambiguous constructor issue between injectable and named parameters counts.
+
 ## 1.6.9 - 2021-08-11
 
 #### Changed

--- a/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
+++ b/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
@@ -22,13 +22,16 @@ namespace RockLib.Configuration.ObjectFactory
             }
             else
             {
-                bool HasAvailableValue(ParameterInfo p) =>
-                    p.GetNames().Any(name => availableMembers.ContainsKey(name)) || resolver.CanResolve(p);
+                bool HasAvailableValue(ParameterInfo p)
+                    => p.GetNames().Any(name => availableMembers.ContainsKey(name)) || resolver.CanResolve(p);
+                bool HasAvailableNamedValue(ParameterInfo p)
+                    => p.GetNames().Any(name => availableMembers.ContainsKey(name));
 
                 IsInvokableWithoutDefaultParameters = parameters.Count(HasAvailableValue) == TotalParameters;
                 IsInvokableWithDefaultParameters = parameters.Count(p => HasAvailableValue(p) || p.HasDefaultValue) == TotalParameters;
                 MissingParameterNames = parameters.Where(p => !HasAvailableValue(p) && !p.HasDefaultValue).Select(p => p.Name);
                 MatchedParameters = parameters.Count(HasAvailableValue);
+                MatchedNamedParameters = parameters.Count(HasAvailableNamedValue);
             }
         }
 
@@ -36,6 +39,7 @@ namespace RockLib.Configuration.ObjectFactory
         public bool IsInvokableWithoutDefaultParameters { get;  }
         public bool IsInvokableWithDefaultParameters { get; }
         public int MatchedParameters { get; }
+        public int MatchedNamedParameters { get; }
         public int TotalParameters { get; }
         public IEnumerable<string> MissingParameterNames { get; }
 
@@ -49,6 +53,8 @@ namespace RockLib.Configuration.ObjectFactory
             if (MatchedParameters < other.MatchedParameters) return 1;
             if (TotalParameters > other.TotalParameters) return -1;
             if (TotalParameters < other.TotalParameters) return 1;
+            if (MatchedNamedParameters > other.MatchedNamedParameters) return -1;
+            if (MatchedNamedParameters < other.MatchedNamedParameters) return 1;
             return 0;
         }
     }

--- a/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
+++ b/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
@@ -22,10 +22,10 @@ namespace RockLib.Configuration.ObjectFactory
             }
             else
             {
-                bool HasAvailableValue(ParameterInfo p)
-                    => p.GetNames().Any(name => availableMembers.ContainsKey(name)) || resolver.CanResolve(p);
-                bool HasAvailableNamedValue(ParameterInfo p)
-                    => p.GetNames().Any(name => availableMembers.ContainsKey(name));
+                bool HasAvailableValue(ParameterInfo p) =>
+                    p.GetNames().Any(name => availableMembers.ContainsKey(name)) || resolver.CanResolve(p);
+                bool HasAvailableNamedValue(ParameterInfo p) =>
+                    p.GetNames().Any(name => availableMembers.ContainsKey(name));
 
                 IsInvokableWithoutDefaultParameters = parameters.Count(HasAvailableValue) == TotalParameters;
                 IsInvokableWithDefaultParameters = parameters.Count(p => HasAvailableValue(p) || p.HasDefaultValue) == TotalParameters;

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/RockLib.Configuration.ObjectFactory.Tests.csproj
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/RockLib.Configuration.ObjectFactory.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="RockLib.UniversalMemberAccessor" Version="1.0.9" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
## Description

Adds a tiebreaker mechanism when constructors with the same number of parameters and have the same number of them matching. In this case, named parameters will be prioritized over injectable parameters. This is specifically written to fix an issue in logging when trying to configure 'processingMode' via appsettings.

<!--

1. Include a summary of the feature or issue being fixed, including relevant
   motivation and context.
2. Highlight any sections or parts that you are unsure about, and note any
   compromises you have made while developing this change.
3. Link to the corresponding issue, if one exists.

-->

## Type of change: 2

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
