### PR TITLE
Update target frameworks

### DIFF
--- a/RockLib.Configuration.ProxyFactory/.editorconfig
+++ b/RockLib.Configuration.ProxyFactory/.editorconfig
@@ -6,6 +6,7 @@ end_of_line = lf
 [*.cs]
 # Styling
 indent_style = space
+indent_size = 4
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_new_line_before_catch = true

--- a/RockLib.Configuration.ProxyFactory/.editorconfig
+++ b/RockLib.Configuration.ProxyFactory/.editorconfig
@@ -1,0 +1,68 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.cs]
+# Styling
+indent_style = space
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = false
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = methods, control_blocks, types, properties, lambdas, accessors, object_collection_array_initializers
+csharp_new_line_between_query_expression_clauses = true
+csharp_prefer_braces = false:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_preferred_modifier_order = public,private,internal,protected,static,readonly,async,override,sealed:suggestion
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+dotnet_sort_system_directives_first = false
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = false:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+
+# Analyzer Configuration
+# These are rules we want to either ignore or have set as suggestion or info
+
+# CA1014: Mark assemblies with CLSCompliant
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# CA1725: Parameter names should match base declaration
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA2227: Collection properties should be read only
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = suggestion

--- a/RockLib.Configuration.ProxyFactory/CHANGELOG.md
+++ b/RockLib.Configuration.ProxyFactory/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Added
+- Added `.editorconfig` and `Directory.Build.props` files to ensure consistency.
+
+#### Changed
+- Supported targets: net6.0, netcoreapp3.1, and net48.
+- As the package now uses nullable reference types, some method parameters now specify if they can accept nullable values.
+
 ## 1.0.7 - 2021-08-11
 
 #### Changed

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -45,7 +45,7 @@ namespace RockLib.Configuration.ProxyFactory
         /// <exception cref="ArgumentException">
         /// If <typeparamref name="T"/> is not an interface or has any declared methods, events, or write-only properties.
         /// </exception>
-        public static T CreateProxy<T>(this IConfiguration configuration, DefaultTypes defaultTypes = null, ValueConverters valueConverters = null) =>
+        public static T CreateProxy<T>(this IConfiguration configuration, DefaultTypes? defaultTypes = null, ValueConverters? valueConverters = null) =>
             (T)configuration.CreateProxy(typeof(T), defaultTypes, valueConverters);
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace RockLib.Configuration.ProxyFactory
         /// <exception cref="ArgumentException">
         /// If <paramref name="type"/> is not an interface or has any declared methods, events, or write-only properties.
         /// </exception>
-        public static object CreateProxy(this IConfiguration configuration, Type type, DefaultTypes defaultTypes = null, ValueConverters valueConverters = null)
+        public static object CreateProxy(this IConfiguration configuration, Type type, DefaultTypes? defaultTypes = null, ValueConverters? valueConverters = null)
         {
             if (configuration is null) throw new ArgumentNullException(nameof(configuration));
             if (type is null) throw new ArgumentNullException(nameof(type));

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -80,7 +80,7 @@ namespace RockLib.Configuration.ProxyFactory
             if (configuration is null) throw new ArgumentNullException(nameof(configuration));
             if (type is null) throw new ArgumentNullException(nameof(type));
             var proxyType = _proxyCache.GetOrAdd(type, CreateProxyType);
-            return configuration.Create(proxyType, defaultTypes, valueConverters);
+            return configuration.Create(proxyType, defaultTypes, valueConverters, null);
         }
 
         private static Type CreateProxyType(Type type)

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -45,8 +45,8 @@ namespace RockLib.Configuration.ProxyFactory
         /// <exception cref="ArgumentException">
         /// If <typeparamref name="T"/> is not an interface or has any declared methods, events, or write-only properties.
         /// </exception>
-        public static T CreateProxy<T>(this IConfiguration configuration, DefaultTypes? defaultTypes = null, ValueConverters? valueConverters = null) =>
-            (T)configuration.CreateProxy(typeof(T), defaultTypes, valueConverters);
+        public static T? CreateProxy<T>(this IConfiguration configuration, DefaultTypes? defaultTypes = null, ValueConverters? valueConverters = null) =>
+            (T)configuration.CreateProxy(typeof(T), defaultTypes, valueConverters)!;
 
         /// <summary>
         /// Returns an instance of a proxy type that implements the interface specified by the <paramref name="type"/>
@@ -75,7 +75,7 @@ namespace RockLib.Configuration.ProxyFactory
         /// <exception cref="ArgumentException">
         /// If <paramref name="type"/> is not an interface or has any declared methods, events, or write-only properties.
         /// </exception>
-        public static object CreateProxy(this IConfiguration configuration, Type type, DefaultTypes? defaultTypes = null, ValueConverters? valueConverters = null)
+        public static object? CreateProxy(this IConfiguration configuration, Type type, DefaultTypes? defaultTypes = null, ValueConverters? valueConverters = null)
         {
             if (configuration is null) throw new ArgumentNullException(nameof(configuration));
             if (type is null) throw new ArgumentNullException(nameof(type));

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -115,7 +115,7 @@ namespace RockLib.Configuration.ProxyFactory
 
             AddConstructor(typeBuilder, readonlyFields);
 
-            return typeBuilder.CreateTypeInfo().AsType();
+            return typeBuilder.CreateTypeInfo()!.AsType();
         }
 
         private static TypeBuilder GetTypeBuilder(Type type)
@@ -189,7 +189,8 @@ namespace RockLib.Configuration.ProxyFactory
                         throw Exceptions.TargetInterfaceCannotHaveAnyMethods(type, m);
                     case EventInfo e:
                         throw Exceptions.TargetInterfaceCannotHaveAnyEvents(type, e);
-                    case PropertyInfo p when p.CanRead && p.GetGetMethod().GetParameters().Length > 0 || p.CanWrite && p.GetSetMethod().GetParameters().Length > 1:
+                    case PropertyInfo p when p.CanRead && p.GetGetMethod()!.GetParameters().Length > 0 ||
+                                             p.CanWrite && p.GetSetMethod()!.GetParameters().Length > 1:
                         throw Exceptions.TargetInterfaceCannotHaveAnyIndexerProperties(type, p);
                     case PropertyInfo p when !p.CanRead:
                         throw Exceptions.TargetInterfaceCannotHaveAnyWriteOnlyProperties(type, p);

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -182,7 +182,10 @@ namespace RockLib.Configuration.ProxyFactory
             {
                 switch (member)
                 {
-                    case MethodInfo m when !m.Name.StartsWith("get_") && !m.Name.StartsWith("set_") && !m.Name.StartsWith("add_") && !m.Name.StartsWith("remove_"):
+                    case MethodInfo m when !m.Name.StartsWith("get_", StringComparison.InvariantCulture) &&
+                                           !m.Name.StartsWith("set_", StringComparison.InvariantCulture) &&
+                                           !m.Name.StartsWith("add_", StringComparison.InvariantCulture) &&
+                                           !m.Name.StartsWith("remove_", StringComparison.InvariantCulture):
                         throw Exceptions.TargetInterfaceCannotHaveAnyMethods(type, m);
                     case EventInfo e:
                         throw Exceptions.TargetInterfaceCannotHaveAnyEvents(type, e);

--- a/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
+++ b/RockLib.Configuration.ProxyFactory/ConfigurationProxyFactory.cs
@@ -77,8 +77,8 @@ namespace RockLib.Configuration.ProxyFactory
         /// </exception>
         public static object CreateProxy(this IConfiguration configuration, Type type, DefaultTypes defaultTypes = null, ValueConverters valueConverters = null)
         {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-            if (type == null) throw new ArgumentNullException(nameof(type));
+            if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+            if (type is null) throw new ArgumentNullException(nameof(type));
             var proxyType = _proxyCache.GetOrAdd(type, CreateProxyType);
             return configuration.Create(proxyType, defaultTypes, valueConverters);
         }

--- a/RockLib.Configuration.ProxyFactory/Directory.Build.props
+++ b/RockLib.Configuration.ProxyFactory/Directory.Build.props
@@ -4,6 +4,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+        <Authors>Rocket Mortgage</Authors>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>

--- a/RockLib.Configuration.ProxyFactory/Directory.Build.props
+++ b/RockLib.Configuration.ProxyFactory/Directory.Build.props
@@ -1,20 +1,20 @@
 <Project>
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-	</PropertyGroup>
-	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    </PropertyGroup>
+    <PropertyGroup>
+        <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <Authors>Rocket Mortgage</Authors>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-		<NoWarn>NU1603,NU1701</NoWarn>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+        <NoWarn>NU1603,NU1701</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/RockLib.Configuration.ProxyFactory/Directory.Build.props
+++ b/RockLib.Configuration.ProxyFactory/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	</PropertyGroup>
+	<PropertyGroup>
+		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<NoWarn>NU1603,NU1701</NoWarn>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/RockLib.Configuration.ProxyFactory/README.md
+++ b/RockLib.Configuration.ProxyFactory/README.md
@@ -2,6 +2,13 @@
 
 A factory that creates instances of property-only interfaces, defined at run-time, and populated with values defined in an instance of `IConfiguration`.
 
+### Supported Targets
+
+This library supports the following targets:
+  - .NET 6
+  - .NET Core 3.1
+  - .NET Framework 4.8
+
 ### Overview
 
 Let's say we have a class, `Foo`, that has various settings that it requires.

--- a/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
+++ b/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <PackageId>RockLib.Configuration.ProxyFactory</PackageId>
     <PackageVersion>1.0.7</PackageVersion>
-    <Authors>RockLib</Authors>
     <Description>Creates proxy objects from interfaces using IConfiguration and IConfigurationSection objects.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Configuration/blob/main/RockLib.Configuration.ProxyFactory/CHANGELOG.md.</PackageReleaseNotes>

--- a/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
+++ b/RockLib.Configuration.ProxyFactory/RockLib.Configuration.ProxyFactory.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard1.6;netstandard2.0;net451;net47</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <PackageId>RockLib.Configuration.ProxyFactory</PackageId>
     <PackageVersion>1.0.7</PackageVersion>
     <Authors>RockLib</Authors>
@@ -41,15 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.6.9" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' Or '$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' Or '$(TargetFramework)'=='net451'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/RockLib.Configuration.ProxyFactory/appveyor.yml
+++ b/RockLib.Configuration.ProxyFactory/appveyor.yml
@@ -1,5 +1,5 @@
 version: 'RockLib.Configuration.ProxyFactory.{build}.0.0-ci'
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 only_commits:
   files:

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/.editorconfig
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/.editorconfig
@@ -6,6 +6,7 @@ end_of_line = lf
 [*.cs]
 # Styling
 indent_style = space
+indent_size = 4
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_new_line_before_catch = true

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/.editorconfig
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/.editorconfig
@@ -1,0 +1,68 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.cs]
+# Styling
+indent_style = space
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = false
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = methods, control_blocks, types, properties, lambdas, accessors, object_collection_array_initializers
+csharp_new_line_between_query_expression_clauses = true
+csharp_prefer_braces = false:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_preferred_modifier_order = public,private,internal,protected,static,readonly,async,override,sealed:suggestion
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+dotnet_sort_system_directives_first = false
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = false:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+
+# Analyzer Configuration
+# These are rules we want to either ignore or have set as suggestion or info
+
+# CA1014: Mark assemblies with CLSCompliant
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1014
+dotnet_diagnostic.CA1014.severity = none
+
+# CA1725: Parameter names should match base declaration
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA2227: Collection properties should be read only
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227
+dotnet_diagnostic.CA2227.severity = suggestion

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/Directory.Build.props
@@ -1,20 +1,20 @@
 <Project>
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-	</PropertyGroup>
-	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    </PropertyGroup>
+    <PropertyGroup>
+        <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <Authors>Rocket Mortgage</Authors>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
-		<NoWarn>NU1603,NU1701</NoWarn>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+        <NoWarn>NU1603,NU1701</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	</PropertyGroup>
+	<PropertyGroup>
+		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+        <Authors>Rocket Mortgage</Authors>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+		<NoWarn>NU1603,NU1701</NoWarn>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp3.1'">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -230,40 +230,44 @@ namespace Tests
 #endif
         }
 
-        private interface IReadonlyProperties
+#pragma warning disable CA1034
+        public interface IReadonlyProperties
         {
             string Bar { get; }
             int Baz { get; }
         }
 
-        private interface IReadWriteProperties
+        public interface IReadWriteProperties
         {
             string Bar { get; set; }
             int Baz { get; set; }
         }
 
 #pragma warning disable CA1812
-        private class NotAnInterface { }
+        public class NotAnInterface { }
 #pragma warning restore CA1812
 
-        private interface IHasMethod
+        public interface IHasMethod
         {
             void Foo();
         }
 
-        private interface IHasEvent
+        public interface IHasEvent
         {
             event EventHandler Foo;
         }
 
-        private interface IHasIndexerProperty
+        public interface IHasIndexerProperty
         {
             int this[string foo] { get; set; }
         }
 
-        private interface IHasWriteOnlyProperty
+        public interface IHasWriteOnlyProperty
         {
+#pragma warning disable CA1044
             int Foo { set; }
+#pragma warning restore CA1044
         }
+#pragma warning restore CA1034
     }
 }

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -242,7 +242,9 @@ namespace Tests
             int Baz { get; set; }
         }
 
+#pragma warning disable CA1812
         private class NotAnInterface { }
+#pragma warning restore CA1812
 
         private interface IHasMethod
         {

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -10,7 +10,7 @@ namespace Tests
     public class ProxyFactoryTests
     {
         [Fact]
-        public void NonGeneric_CanCreateProxyForReadonlyProperties()
+        public void NonGenericCanCreateProxyForReadonlyProperties()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -31,7 +31,7 @@ namespace Tests
         }
 
         [Fact]
-        public void NonGeneric_CanCreateProxyForReadWriteProperties()
+        public void NonGenericCanCreateProxyForReadWriteProperties()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -59,7 +59,7 @@ namespace Tests
         }
 
         [Fact]
-        public void Generic_CanCreateProxyForReadonlyProperties()
+        public void GenericCanCreateProxyForReadonlyProperties()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -76,7 +76,7 @@ namespace Tests
         }
 
         [Fact]
-        public void Generic_CanCreateProxyForReadWriteProperties()
+        public void GenericCanCreateProxyForReadWriteProperties()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -100,7 +100,7 @@ namespace Tests
         }
 
         [Fact]
-        public void NonGeneric_GivenNullConfiguration_ThrowsArgumentNullException()
+        public void NonGenericGivenNullConfigurationThrowsArgumentNullException()
         {
             IConfiguration fooSection = null!;
 
@@ -108,7 +108,7 @@ namespace Tests
         }
 
         [Fact]
-        public void NonGeneric_GivenNullType_ThrowsArgumentNullException()
+        public void NonGenericGivenNullTypeThrowsArgumentNullException()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -123,7 +123,7 @@ namespace Tests
         }
 
         [Fact]
-        public void Generic_GivenNullConfiguration_ThrowsArgumentNullException()
+        public void GenericGivenNullConfigurationThrowsArgumentNullException()
         {
             IConfiguration fooSection = null!;
 
@@ -131,7 +131,7 @@ namespace Tests
         }
 
         [Fact]
-        public void GivenTypeIsNotAnInterface_ThrowsArgumentException()
+        public void GivenTypeIsNotAnInterfaceThrowsArgumentException()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -151,7 +151,7 @@ namespace Tests
         }
 
         [Fact]
-        public void GivenInterfaceTypeDefinesAMethod_ThrowsArgumentException()
+        public void GivenInterfaceTypeDefinesAMethodThrowsArgumentException()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -171,7 +171,7 @@ namespace Tests
         }
 
         [Fact]
-        public void GivenInterfaceTypeDefinesAnEvent_ThrowsArgumentException()
+        public void GivenInterfaceTypeDefinesAnEventThrowsArgumentException()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -191,7 +191,7 @@ namespace Tests
         }
 
         [Fact]
-        public void GivenInterfaceTypeDefinesAnIndexerProperty_ThrowsArgumentException()
+        public void GivenInterfaceTypeDefinesAnIndexerPropertyThrowsArgumentException()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>
@@ -211,7 +211,7 @@ namespace Tests
         }
 
         [Fact]
-        public void GivenInterfaceTypeDefinesAWriteOnlyProperty_ThrowsArgumentException()
+        public void GivenInterfaceTypeDefinesAWriteOnlyPropertyThrowsArgumentException()
         {
             var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string>

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -102,7 +102,7 @@ namespace Tests
         [Fact]
         public void NonGeneric_GivenNullConfiguration_ThrowsArgumentNullException()
         {
-            IConfiguration fooSection = null;
+            IConfiguration fooSection = null!;
 
             Assert.Throws<ArgumentNullException>(() => fooSection.CreateProxy(typeof(IReadonlyProperties)));
         }
@@ -125,7 +125,7 @@ namespace Tests
         [Fact]
         public void Generic_GivenNullConfiguration_ThrowsArgumentNullException()
         {
-            IConfiguration fooSection = null;
+            IConfiguration fooSection = null!;
 
             Assert.Throws<ArgumentNullException>(() => fooSection.CreateProxy<IReadonlyProperties>());
         }

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -71,7 +71,7 @@ namespace Tests
             var fooSection = config.GetSection("foo");
             var foo = fooSection.CreateProxy<IReadonlyProperties>();
 
-            Assert.Equal("abcdefg", foo.Bar);
+            Assert.Equal("abcdefg", foo!.Bar);
             Assert.Equal(123, foo.Baz);
         }
 
@@ -88,7 +88,7 @@ namespace Tests
             var fooSection = config.GetSection("foo");
             var foo = fooSection.CreateProxy<IReadWriteProperties>();
 
-            Assert.Equal("abcdefg", foo.Bar);
+            Assert.Equal("abcdefg", foo!.Bar);
             Assert.Equal(123, foo.Baz);
 
             // Make sure getters and setters work as expected.

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -230,36 +230,36 @@ namespace Tests
 #endif
         }
 
-        public interface IReadonlyProperties
+        private interface IReadonlyProperties
         {
             string Bar { get; }
             int Baz { get; }
         }
 
-        public interface IReadWriteProperties
+        private interface IReadWriteProperties
         {
             string Bar { get; set; }
             int Baz { get; set; }
         }
 
-        public class NotAnInterface { }
+        private class NotAnInterface { }
 
-        public interface IHasMethod
+        private interface IHasMethod
         {
             void Foo();
         }
 
-        public interface IHasEvent
+        private interface IHasEvent
         {
             event EventHandler Foo;
         }
 
-        public interface IHasIndexerProperty
+        private interface IHasIndexerProperty
         {
             int this[string foo] { get; set; }
         }
 
-        public interface IHasWriteOnlyProperty
+        private interface IHasWriteOnlyProperty
         {
             int Foo { set; }
         }

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -24,7 +24,7 @@ namespace Tests
 
             Assert.IsAssignableFrom<IReadonlyProperties>(fooObject);
 
-            var foo = (IReadonlyProperties)fooObject;
+            var foo = (IReadonlyProperties)fooObject!;
 
             Assert.Equal("abcdefg", foo.Bar);
             Assert.Equal(123, foo.Baz);
@@ -45,7 +45,7 @@ namespace Tests
 
             Assert.IsAssignableFrom<IReadWriteProperties>(fooObject);
 
-            var foo = (IReadWriteProperties)fooObject;
+            var foo = (IReadWriteProperties)fooObject!;
 
             Assert.Equal("abcdefg", foo.Bar);
             Assert.Equal(123, foo.Baz);

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -165,7 +165,7 @@ namespace Tests
             var ex = Assert.Throws<ArgumentException>(() => fooSection.CreateProxy<IHasMethod>());
 
 #if DEBUG
-            var expected = Exceptions.TargetInterfaceCannotHaveAnyMethods(typeof(IHasMethod), typeof(IHasMethod).GetTypeInfo().GetMethod("Foo"));
+            var expected = Exceptions.TargetInterfaceCannotHaveAnyMethods(typeof(IHasMethod), typeof(IHasMethod).GetTypeInfo().GetMethod("Foo")!);
             Assert.Equal(expected.Message, ex.Message);
 #endif
         }
@@ -185,7 +185,7 @@ namespace Tests
             var ex = Assert.Throws<ArgumentException>(() => fooSection.CreateProxy<IHasEvent>());
 
 #if DEBUG
-            var expected = Exceptions.TargetInterfaceCannotHaveAnyEvents(typeof(IHasEvent), typeof(IHasEvent).GetTypeInfo().GetEvent("Foo"));
+            var expected = Exceptions.TargetInterfaceCannotHaveAnyEvents(typeof(IHasEvent), typeof(IHasEvent).GetTypeInfo().GetEvent("Foo")!);
             Assert.Equal(expected.Message, ex.Message);
 #endif
         }
@@ -225,7 +225,7 @@ namespace Tests
             var ex = Assert.Throws<ArgumentException>(() => fooSection.CreateProxy<IHasWriteOnlyProperty>());
 
 #if DEBUG
-            var expected = Exceptions.TargetInterfaceCannotHaveAnyWriteOnlyProperties(typeof(IHasWriteOnlyProperty), typeof(IHasWriteOnlyProperty).GetTypeInfo().GetProperty("Foo"));
+            var expected = Exceptions.TargetInterfaceCannotHaveAnyWriteOnlyProperties(typeof(IHasWriteOnlyProperty), typeof(IHasWriteOnlyProperty).GetTypeInfo().GetProperty("Foo")!);
             Assert.Equal(expected.Message, ex.Message);
 #endif
         }

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/ProxyFactoryTests.cs
@@ -119,7 +119,7 @@ namespace Tests
 
             var fooSection = config.GetSection("foo");
 
-            Assert.Throws<ArgumentNullException>(() => fooSection.CreateProxy(null));
+            Assert.Throws<ArgumentNullException>(() => fooSection.CreateProxy(null!));
         }
 
         [Fact]

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/RockLib.Configuration.ProxyFactory.Tests.csproj
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/RockLib.Configuration.ProxyFactory.Tests.csproj
@@ -1,21 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>net5.0;netcoreapp3.1;net462;</TargetFrameworks>    
     <RootNamespace>Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="RockLib.UniversalMemberAccessor" Version="1.0.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description

Updated target frameworks to support only net6.0, netcoreapp3.1, and net48.

Added .editorconfig and Directory.Build.props for consistency

## Type of change: 
This is a breaking change and will be updated version to 2.0.0.

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
