### PR TITLE
Constructor Comparison Update

### DIFF
--- a/RockLib.Configuration.ObjectFactory/CHANGELOG.md
+++ b/RockLib.Configuration.ObjectFactory/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Changed
+
+- Updated `ToCompare()` method in `ConstructorOrderInfo` to also compare the parameter types during comparison.
+
 ## 2.0.0 - 2022-02-07
 
 #### Added

--- a/RockLib.Configuration.ObjectFactory/CHANGELOG.md
+++ b/RockLib.Configuration.ObjectFactory/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- Updated `ToCompare()` method in `ConstructorOrderInfo` to also compare the parameter types during comparison.
+- Updated `CompareTo()` method in `ConstructorOrderInfo` to also compare the parameter types during comparison.
 
 ## 2.0.0 - 2022-02-07
 

--- a/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
+++ b/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
@@ -32,6 +32,7 @@ namespace RockLib.Configuration.ObjectFactory
             MissingParameterNames = parameters.Where(p => !HasAvailableValue(p) && !p.HasDefaultValue).Select(p => p.Name!);
             MatchedParameters = parameters.Count(HasAvailableValue);
             MatchedNamedParameters = parameters.Count(HasAvailableNamedValue);
+            ParameterTypes = parameters.Select(p => p.ParameterType);
          }
       }
 
@@ -40,6 +41,7 @@ namespace RockLib.Configuration.ObjectFactory
       public bool IsInvokableWithDefaultParameters { get; }
       public int MatchedParameters { get; }
       public int MatchedNamedParameters { get; }
+      public IEnumerable<Type>? ParameterTypes { get; }
       public int TotalParameters { get; }
       public IEnumerable<string> MissingParameterNames { get; }
 
@@ -56,6 +58,11 @@ namespace RockLib.Configuration.ObjectFactory
          if (TotalParameters < other.TotalParameters) return 1;
          if (MatchedNamedParameters > other.MatchedNamedParameters) return -1;
          if (MatchedNamedParameters < other.MatchedNamedParameters) return 1;
+         if (ParameterTypes is not null && other.ParameterTypes is not null)
+         {
+            if (ParameterTypes.Except(other.ParameterTypes).Any()) return -1;
+            if (other.ParameterTypes.Except(ParameterTypes).Any()) return 1;
+         }
          return 0;
       }
    }

--- a/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
+++ b/RockLib.Configuration.ObjectFactory/ConstructorOrderInfo.cs
@@ -17,8 +17,9 @@ namespace RockLib.Configuration.ObjectFactory
          {
             IsInvokableWithoutDefaultParameters = true;
             IsInvokableWithDefaultParameters = true;
-            MissingParameterNames = Enumerable.Empty<string>();
+            MissingParameterNames = new List<string>();
             MatchedParameters = 0;
+            ParameterTypes = new List<Type>();
          }
          else
          {
@@ -29,10 +30,10 @@ namespace RockLib.Configuration.ObjectFactory
 
             IsInvokableWithoutDefaultParameters = parameters.Count(HasAvailableValue) == TotalParameters;
             IsInvokableWithDefaultParameters = parameters.Count(p => HasAvailableValue(p) || p.HasDefaultValue) == TotalParameters;
-            MissingParameterNames = parameters.Where(p => !HasAvailableValue(p) && !p.HasDefaultValue).Select(p => p.Name!);
+            MissingParameterNames = parameters.Where(p => !HasAvailableValue(p) && !p.HasDefaultValue).Select(p => p.Name!).ToList();
             MatchedParameters = parameters.Count(HasAvailableValue);
             MatchedNamedParameters = parameters.Count(HasAvailableNamedValue);
-            ParameterTypes = parameters.Select(p => p.ParameterType);
+            ParameterTypes = parameters.Select(p => p.ParameterType).ToList();
          }
       }
 
@@ -41,9 +42,9 @@ namespace RockLib.Configuration.ObjectFactory
       public bool IsInvokableWithDefaultParameters { get; }
       public int MatchedParameters { get; }
       public int MatchedNamedParameters { get; }
-      public IEnumerable<Type>? ParameterTypes { get; }
+      public List<Type> ParameterTypes { get; }
       public int TotalParameters { get; }
-      public IEnumerable<string> MissingParameterNames { get; }
+      public List<string> MissingParameterNames { get; }
 
       public int CompareTo(ConstructorOrderInfo? other)
       {
@@ -58,11 +59,10 @@ namespace RockLib.Configuration.ObjectFactory
          if (TotalParameters < other.TotalParameters) return 1;
          if (MatchedNamedParameters > other.MatchedNamedParameters) return -1;
          if (MatchedNamedParameters < other.MatchedNamedParameters) return 1;
-         if (ParameterTypes is not null && other.ParameterTypes is not null)
-         {
-            if (ParameterTypes.Except(other.ParameterTypes).Any()) return -1;
-            if (other.ParameterTypes.Except(ParameterTypes).Any()) return 1;
-         }
+         // Finds parameter types in ParameterTypes that are not in other.ParameterTypes
+         if (ParameterTypes.Except(other.ParameterTypes).Any()) return -1;
+         // Finds parameter types in other.ParameterTypes that are not in ParameterTypes
+         if (other.ParameterTypes.Except(ParameterTypes).Any()) return 1;
          return 0;
       }
    }

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigurationObjectFactorySadPathTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigurationObjectFactorySadPathTests.cs
@@ -314,26 +314,6 @@ namespace Tests
 #endif
       }
 
-      [Fact]
-      public void GivenATargetTypeWithAmbiguousConstructorsThrowsInvalidOperationException()
-      {
-         var config = new ConfigurationBuilder()
-             .AddInMemoryCollection(new Dictionary<string, string>
-             {
-                    { "foo:bar", "123.45" },
-                    { "foo:baz", "456" },
-             })
-             .Build();
-
-         var fooSection = config.GetSection("foo");
-         var actual = Assert.Throws<InvalidOperationException>(() => fooSection.Create<AmbiguousConstructorsClass>());
-
-#if DEBUG
-            var expected = Exceptions.AmbiguousConstructors(typeof(AmbiguousConstructorsClass));
-            Assert.Equal(expected.Message, actual.Message);
-#endif
-      }
-
       [Theory]
       [InlineData(typeof(double))]
       [InlineData(typeof(Corge))]

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigurationObjectFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigurationObjectFactoryTests.cs
@@ -14,7 +14,48 @@ namespace Tests
 #pragma warning disable CA1034 // Nested types should not be visible
    public class ConfigurationObjectFactoryTests
    {
-      [Fact]
+        [Fact]
+        public void SameConstructorWithDifferentParameterType()
+        {
+            var config = new ConfigurationBuilder()
+             .AddInMemoryCollection(new Dictionary<string, string>
+             {
+                    { "MatchingConstructorsWithDifferenthParamType:name", "test" },
+                    { "MatchingConstructorsWithDifferenthParamType:url", "https://www.google.com" }
+             })
+             .Build();
+
+            var fooSection = config.GetSection("MatchingConstructorsWithDifferenthParamType");
+            var foo = fooSection.Create<MatchingConstructorsWithDifferenthParamType>()!;
+            Assert.Equal("test", foo.Name);
+            Assert.Equal(new Uri("https://www.google.com"), foo.Url);
+            Assert.Equal("POST", foo.Method);
+            Assert.Null(foo.DefaultHeaders);
+        }
+
+        public class MatchingConstructorsWithDifferenthParamType
+        {
+            public string Name { get; }
+            public Uri Url { get; }
+            public string Method { get; set; }
+            public IReadOnlyDictionary<string, string>? DefaultHeaders { get; set; }
+            public MatchingConstructorsWithDifferenthParamType(string name, Uri url, string method = "POST", IReadOnlyDictionary<string, string>? defaultHeaders = null)
+            {
+                Name = name;
+                Url = url;
+                Method = method;
+                DefaultHeaders = defaultHeaders;
+            }
+            public MatchingConstructorsWithDifferenthParamType(string name, string url, string method = "POST", IReadOnlyDictionary<string, string>? defaultHeaders = null) 
+            {
+                Name = name;
+                Url = new Uri(url);
+                Method = method;
+                DefaultHeaders = defaultHeaders;
+            }
+        }
+
+        [Fact]
       public void SupportsCustomTypeImplementingIEnumerable()
       {
          var config = new ConfigurationBuilder()
@@ -39,7 +80,6 @@ namespace Tests
              .Build();
 
          var baz = config.GetSection("baz").Create<Baz>()!;
-
          Assert.Equal(123, baz.GetFoo());
          var bar = baz.GetBar();
          Assert.IsType<AnotherBar>(bar);

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ConstructorOrderInfoTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ConstructorOrderInfoTests.cs
@@ -218,7 +218,7 @@ namespace Tests
          public ConstructorsWithMatchingParamCount(string notOne, double two = 2, decimal three = 3, object? four = null) { }
          public ConstructorsWithMatchingParamCount(string name, Uri url, string method = "POST", IReadOnlyDictionary<string, string>? defaultHeaders = null) { }
          public ConstructorsWithMatchingParamCount(string name, string url, string method = "POST", IReadOnlyDictionary<string, string>? defaultHeaders = null) { }
-        }
+      }
 #pragma warning restore CA1812
    }
 }

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ConstructorOrderInfoTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ConstructorOrderInfoTests.cs
@@ -169,6 +169,27 @@ namespace Tests
          Assert.Equal(-1, orderInfo1.CompareTo(orderInfo2));
       }
 
+
+      [Theory]
+      [InlineData(2, 3, -1)]
+      [InlineData(3, 2, 1)]
+      [InlineData(2, 2, 0)]
+      public void CompareParameterTypes(int constructorOneIndex, int constructorTwoIndex, int expectedComparisonValue)
+      {
+         var constructors = typeof(ConstructorsWithMatchingParamCount).GetConstructors();
+         var members = new Dictionary<string, IConfigurationSection>
+            {
+                { "name", null! },
+                { "url", null! }
+            };
+         var resolver = new Resolver(t => t, t => t == typeof(string) ? true : false);
+
+         var orderInfo1 = _constructorOrderInfoType.New(constructors[constructorOneIndex], members, resolver);
+         var orderInfo2 = _constructorOrderInfoType.New(constructors[constructorTwoIndex], members, resolver);
+
+         Assert.Equal(expectedComparisonValue, orderInfo1.CompareTo(orderInfo2));
+      }
+
 #pragma warning disable CA1812
       private class DefaultConstructor { }
       private class OneParameter { public OneParameter(int bar) { } }
@@ -195,7 +216,9 @@ namespace Tests
       {
          public ConstructorsWithMatchingParamCount(int one = 1, double two = 2, decimal three = 3, object? four = null) { }
          public ConstructorsWithMatchingParamCount(string notOne, double two = 2, decimal three = 3, object? four = null) { }
-      }
+         public ConstructorsWithMatchingParamCount(string name, Uri url, string method = "POST", IReadOnlyDictionary<string, string>? defaultHeaders = null) { }
+         public ConstructorsWithMatchingParamCount(string name, string url, string method = "POST", IReadOnlyDictionary<string, string>? defaultHeaders = null) { }
+        }
 #pragma warning restore CA1812
    }
 }


### PR DESCRIPTION
## Description

Updated the `ToCompare()` method in `ConstructorOrderInfo` to also compare the parameter types during comparison.

## Type of change: 2

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
