### PR TITLE
Add support for generic host

### DIFF
--- a/RockLib.Configuration/RockLibConfigurationBuilderExtensions.cs
+++ b/RockLib.Configuration/RockLibConfigurationBuilderExtensions.cs
@@ -56,6 +56,9 @@ namespace RockLib.Configuration
             var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
 
             if (string.IsNullOrEmpty(environment))
+                environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+
+            if (string.IsNullOrEmpty(environment))
                 environment = Environment.GetEnvironmentVariable("ROCKLIB_ENVIRONMENT");
 
             if (!string.IsNullOrEmpty(environment))


### PR DESCRIPTION
## Description
Fills a gap for dotnet generic hosts, which look for environment variables prefixed with `DOTNET_` ([ref docs](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-6.0#default-builder-settings)). Without this, generic host projects are not able to load environment specific appsettings files.

## Type of change: 2/3 - can go either way

1. Non-functional change (e.g. documentation changes, removing unused `using` directives, renaming local variables, etc)
2. Bug fix (non-breaking change that fixes an issue)
3. New feature (non-breaking change that adds functionality)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)

## Checklist:

- Have you reviewed your own code? Do you understand every change?
- Are you following the [contributing guidelines](../blob/main/CONTRIBUTING.md)?
- Have you added tests that prove your fix is effective or that this feature works?
- New and existing unit tests pass locally with these changes?
- Have you made corresponding changes to the documentation?
- Will this change require an update to an example project? (if so, create an issue and link to it)

---

<sup>_[Reviewer guidelines](../blob/main/CONTRIBUTING.md#reviewing-changes)_</sup>
