### PR TITLE
Memory Leak Fix

### DIFF
--- a/Examples/Example.MemoryLeakTest/Example.MemoryLeakTest.csproj
+++ b/Examples/Example.MemoryLeakTest/Example.MemoryLeakTest.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\RockLib.Configuration.ObjectFactory\RockLib.Configuration.ObjectFactory.csproj" />
+		<ProjectReference Include="..\..\RockLib.Configuration\RockLib.Configuration.csproj" />
+	</ItemGroup>
+</Project>

--- a/Examples/Example.MemoryLeakTest/Program.cs
+++ b/Examples/Example.MemoryLeakTest/Program.cs
@@ -2,8 +2,11 @@
 using RockLib.Configuration.ObjectFactory;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+
+var baseWorkingSet = Process.GetCurrentProcess().WorkingSet64;
 
 while (true)
 {
@@ -18,7 +21,9 @@ while (true)
 
 	await Task.WhenAll(tasks);
 
-	Console.WriteLine(Tester._total);
+	var currentWorkingSet = Process.GetCurrentProcess().WorkingSet64;
+	//Console.WriteLine($"Current count: {Tester._total}");
+	Console.WriteLine($"Current working set: {currentWorkingSet} - diff is {((currentWorkingSet - baseWorkingSet) / (double)baseWorkingSet) * 100}");
 	Console.ReadLine();
 }
 
@@ -42,40 +47,9 @@ public class Tester
 
 	public class Logger : ILogger
 	{
-		public Logger()
-		{
+		public Logger() { }
 
-		}
-		private bool disposedValue;
-
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!disposedValue)
-			{
-				if (disposing)
-				{
-					// TODO: dispose managed state (managed objects)
-				}
-
-				// TODO: free unmanaged resources (unmanaged objects) and override finalizer
-				// TODO: set large fields to null
-				disposedValue = true;
-			}
-		}
-
-		// // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-		//~Logger()
-		//{
-		//    // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-		//    Dispose(disposing: false);
-		//}
-
-		public void Dispose()
-		{
-			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-			Dispose(disposing: true);
-			GC.SuppressFinalize(this);
-		}
+		public void Dispose() { }
 	}
 
 	public void Log(int i)
@@ -94,15 +68,14 @@ public class Tester
 		}
 		finally
 		{
-			//logger?.Dispose();
-			(logger as ConfigReloadingProxy<ILogger>)?.Dispose();
+			//logger.Dispose();
 		}
 		Interlocked.Decrement(ref _counter);
 		Interlocked.Increment(ref _total);
 
 		int count = _total;
 
-		if (count % 1000 == 0)
-			Console.WriteLine(count);
+		//if (count % 1000 == 0)
+		//	Console.WriteLine(count);
 	}
 }

--- a/Examples/Example.MemoryLeakTest/Program.cs
+++ b/Examples/Example.MemoryLeakTest/Program.cs
@@ -1,0 +1,108 @@
+﻿using RockLib.Configuration;
+using RockLib.Configuration.ObjectFactory;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+while (true)
+{
+	await new Tester().Test();
+
+	var tasks = new List<Task>();
+
+	for (var i = 0; i < 8; i++)
+	{
+		tasks.Add(Task.Run(async () => await new Tester().Test()));
+	}
+
+	await Task.WhenAll(tasks);
+
+	Console.WriteLine(Tester._total);
+	Console.ReadLine();
+}
+
+public class Tester
+{
+	private static int _counter = 0;
+	public static int _total = 0;
+
+	public async Task Test()
+	{
+		for (int i = 0; i < 10000; i++)
+		{
+			var count = i;
+			Log(count);
+		}
+
+		await Task.CompletedTask;
+	}
+
+	public interface ILogger : IDisposable { }
+
+	public class Logger : ILogger
+	{
+		public Logger()
+		{
+
+		}
+		private bool disposedValue;
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!disposedValue)
+			{
+				if (disposing)
+				{
+					// TODO: dispose managed state (managed objects)
+				}
+
+				// TODO: free unmanaged resources (unmanaged objects) and override finalizer
+				// TODO: set large fields to null
+				disposedValue = true;
+			}
+		}
+
+		// // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+		//~Logger()
+		//{
+		//    // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		//    Dispose(disposing: false);
+		//}
+
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+	}
+
+	public void Log(int i)
+	{
+		Interlocked.Increment(ref _counter);
+
+		var config = Config.Root.GetCompositeSection("RockLib_Logging", "RockLib.Logging");
+		var defaultTypes = new DefaultTypes();
+		if (!defaultTypes.TryGet(typeof(ILogger), out var dummy))
+			defaultTypes.Add(typeof(ILogger), typeof(Logger));
+
+		ILogger logger = null;
+		try
+		{
+			logger = config.CreateReloadingProxy<ILogger>(defaultTypes, null, null);
+		}
+		finally
+		{
+			//logger?.Dispose();
+			(logger as ConfigReloadingProxy<ILogger>)?.Dispose();
+		}
+		Interlocked.Decrement(ref _counter);
+		Interlocked.Increment(ref _total);
+
+		int count = _total;
+
+		if (count % 1000 == 0)
+			Console.WriteLine(count);
+	}
+}

--- a/RockLib.Configuration.ObjectFactory/CHANGELOG.md
+++ b/RockLib.Configuration.ObjectFactory/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
+**BREAKING CHANGES**
+
 - This is a bug fix that can be a breaking change. This fix eliminates a memory leak that can occur with `ConfigReloadingProxy`. The type passed to `CreateReloadingProxy()` must now implement `IDisposable`. Note that this is a runtime check, so you should check any `Type` objects passed to this method and make the appropriate updates in your code. Otherwise, your code will fail with `ArgumentException`-based exceptions. Review your code to ensure:
   - The interface passed to `CreateReloadingProxy()` must now implement `IDisposable`
   - This also means that you must call `Dispose()` on the object reference returned by `CreateReloadingProxy()`

--- a/RockLib.Configuration.ObjectFactory/CHANGELOG.md
+++ b/RockLib.Configuration.ObjectFactory/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- This is a bug fix that can be a breaking change. This fix eliminates a memory leak that can occur with `ConfigReloadingProxy` . The type passed to `CreateReloadingProxy()` must now implement `IDisposable`. Note that this is a runtime check, so you should check any `Type` objects passed to this method and make the appropriate updates in your code.
+- This is a bug fix that can be a breaking change. This fix eliminates a memory leak that can occur with `ConfigReloadingProxy`. The type passed to `CreateReloadingProxy()` must now implement `IDisposable`. Note that this is a runtime check, so you should check any `Type` objects passed to this method and make the appropriate updates in your code. Otherwise, your code will fail with `ArgumentException`-based exceptions. Review your code to ensure:
+  - The interface passed to `CreateReloadingProxy()` must now implement `IDisposable`
+  - This also means that you must call `Dispose()` on the object reference returned by `CreateReloadingProxy()`
 
 ## 2.0.1 - 2022-04-25
 

--- a/RockLib.Configuration.ObjectFactory/CHANGELOG.md
+++ b/RockLib.Configuration.ObjectFactory/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.2 - 2022-06-06
+
+#### Changed
+
+- This is a bug fix that can be a breaking change. This fix eliminates a memory leak that can occur with `ConfigReloadingProxy` . The type passed to `CreateReloadingProxy()` must now implement `IDisposable`. Note that this is a runtime check, so you should check any `Type` objects passed to this method and make the appropriate updates in your code.
+
 ## 2.0.1 - 2022-04-25
 
 #### Changed

--- a/RockLib.Configuration.ObjectFactory/ConfigReloadingProxy.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigReloadingProxy.cs
@@ -16,9 +16,7 @@ namespace RockLib.Configuration.ObjectFactory
    /// The base class for reloading proxy classes.
    /// </summary>
    [DebuggerDisplay("{" + nameof(Object) + "}")]
-#pragma warning disable CA1063 // Implement IDisposable Correctly
    public abstract class ConfigReloadingProxy<TInterface> : IDisposable
-#pragma warning restore CA1063 // Implement IDisposable Correctly
    {
       [DebuggerBrowsable(DebuggerBrowsableState.Never)] private readonly IConfiguration _section;
       [DebuggerBrowsable(DebuggerBrowsableState.Never)] private readonly DefaultTypes _defaultTypes;

--- a/RockLib.Configuration.ObjectFactory/ConfigReloadingProxy.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigReloadingProxy.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections;
 using System.Diagnostics;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -28,6 +27,8 @@ namespace RockLib.Configuration.ObjectFactory
       [DebuggerBrowsable(DebuggerBrowsableState.Never)] private readonly string _memberName;
       [DebuggerBrowsable(DebuggerBrowsableState.Never)] private readonly IResolver _resolver;
       [DebuggerBrowsable(DebuggerBrowsableState.Never)] private string _hash;
+
+      private readonly IDisposable _reloadedObject;
 
       private readonly object _thisLock = new();
 
@@ -66,7 +67,7 @@ namespace RockLib.Configuration.ObjectFactory
          _resolver = resolver ?? Resolver.Empty;
          _hash = GetHash();
          Object = CreateObject();
-         ChangeToken.OnChange(section.GetReloadToken, () => ReloadObject(false));
+         _reloadedObject = ChangeToken.OnChange(section.GetReloadToken, () => ReloadObject(false));
       }
 
       /// <summary>
@@ -93,13 +94,27 @@ namespace RockLib.Configuration.ObjectFactory
       public event EventHandler? Reloaded;
 
       /// <summary>
+      /// Standard implementation of Dispose
+      /// </summary>
+      public void Dispose()
+      {
+          Dispose(true);
+          GC.SuppressFinalize(this);
+      }
+
+      /// <summary>
       /// Dispose the underlying object if it implements <see cref="IDisposable"/>.
       /// </summary>
-#pragma warning disable CA1063 // Implement IDisposable Correctly
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-      public void Dispose() => (Object as IDisposable)?.Dispose();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-#pragma warning restore CA1063 // Implement IDisposable Correctly
+      /// <param name="disposing"></param>
+      protected virtual void Dispose(bool disposing)
+      {
+          if (!disposing)
+          {
+              return;
+          }
+          _reloadedObject.Dispose();
+          (Object as IDisposable)?.Dispose();
+      }
 
       private TInterface CreateObject()
       {

--- a/RockLib.Configuration.ObjectFactory/ConfigReloadingProxyFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigReloadingProxyFactory.cs
@@ -129,7 +129,7 @@ namespace RockLib.Configuration.ObjectFactory
          DefaultTypes? defaultTypes = null, ValueConverters? valueConverters = null, IResolver? resolver = null) =>
             configuration.CreateReloadingProxy(interfaceType, defaultTypes, valueConverters, null, null, resolver ?? Resolver.Empty);
 
-      internal static object CreateReloadingProxy(this IConfiguration configuration, Type interfaceType, 
+      internal static object CreateReloadingProxy(this IConfiguration configuration, Type interfaceType,
          DefaultTypes? defaultTypes, ValueConverters? valueConverters, Type? declaringType, string? memberName, IResolver? resolver)
       {
          if (configuration is null)
@@ -138,7 +138,7 @@ namespace RockLib.Configuration.ObjectFactory
             throw new ArgumentNullException(nameof(interfaceType));
          if (!interfaceType.IsInterface)
             throw new ArgumentException($"Specified type is not an interface: '{interfaceType.FullName}'.", nameof(interfaceType));
-         if (!DoesImplementDisposable(interfaceType))
+         if (!typeof(IDisposable).IsAssignableFrom(interfaceType))
             throw new ArgumentException("The Specified type does not implement IDisposable.");
          if (interfaceType == typeof(IEnumerable))
             throw new ArgumentException("The IEnumerable interface is not supported.");
@@ -414,13 +414,5 @@ namespace RockLib.Configuration.ObjectFactory
 
       private static IEnumerable<EventInfo> GetAllEvents(this Type type) =>
           type.GetEvents().Concat(type.GetInterfaces().SelectMany(i => i.GetEvents()));
-
-      private static bool DoesImplementDisposable(Type t)
-      {
-          var interfaceMap = t.GetInterfaceMap(typeof(IDisposable));
-          var methodInfo = t.GetMethod("Dispose");
-
-          return methodInfo == interfaceMap.TargetMethods[0];
-      }
    }
 }

--- a/RockLib.Configuration.ObjectFactory/ConfigReloadingProxyFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigReloadingProxyFactory.cs
@@ -139,7 +139,7 @@ namespace RockLib.Configuration.ObjectFactory
          if (!interfaceType.IsInterface)
             throw new ArgumentException($"Specified type is not an interface: '{interfaceType.FullName}'.", nameof(interfaceType));
          if (!typeof(IDisposable).IsAssignableFrom(interfaceType))
-            throw new ArgumentException("The Specified type does not implement IDisposable.");
+            throw new ArgumentException($"The specified type, {interfaceType.FullName}, does not implement IDisposable.", nameof(interfaceType));
          if (interfaceType == typeof(IEnumerable))
             throw new ArgumentException("The IEnumerable interface is not supported.");
          if (typeof(IEnumerable).IsAssignableFrom(interfaceType))

--- a/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.csproj
+++ b/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.csproj
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>RockLib.Configuration.ObjectFactory</PackageId>
-		<PackageVersion>2.0.1</PackageVersion>
+		<PackageVersion>2.0.2</PackageVersion>
 		<Authors>RockLib</Authors>
 		<Description>Creates objects from IConfiguration and IConfigurationSection objects. A replacement for some of the functionality of Microsoft.Extensions.Configuration.Binder.</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -14,7 +14,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<Copyright>Copyright 2017-2021 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<PackageTags>Configuration Factory Binder IConfiguration IConfigurationSection</PackageTags>
-		<Version>2.0.1</Version>
+		<Version>2.0.2</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<EmbedUntrackedSources>True</EmbedUntrackedSources>

--- a/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.sln
+++ b/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.sln
@@ -7,10 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.Objec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.ObjectFactory.Tests", "..\Tests\RockLib.Configuration.ObjectFactory.Tests\RockLib.Configuration.ObjectFactory.Tests.csproj", "{9DA180C2-E6BD-42E3-B157-D3164F6F269F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example.MemoryLeakTest", "..\Examples\Example.MemoryLeakTest\Example.MemoryLeakTest.csproj", "{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration", "..\RockLib.Configuration\RockLib.Configuration.csproj", "{5F36925C-7C91-4837-8195-5ECBB50EFE0A}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,18 +26,6 @@ Global
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.ReferenceModel|Any CPU.Build.0 = ReferenceModel|Any CPU
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.ReferenceModel|Any CPU.ActiveCfg = Release|Any CPU
-		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.ReferenceModel|Any CPU.Build.0 = Release|Any CPU
-		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.ReferenceModel|Any CPU.ActiveCfg = Release|Any CPU
-		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.ReferenceModel|Any CPU.Build.0 = Release|Any CPU
-		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.sln
+++ b/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.sln
@@ -7,6 +7,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.Objec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.ObjectFactory.Tests", "..\Tests\RockLib.Configuration.ObjectFactory.Tests\RockLib.Configuration.ObjectFactory.Tests.csproj", "{9DA180C2-E6BD-42E3-B157-D3164F6F269F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example.MemoryLeakTest", "..\Examples\Example.MemoryLeakTest\Example.MemoryLeakTest.csproj", "{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration", "..\RockLib.Configuration\RockLib.Configuration.csproj", "{5F36925C-7C91-4837-8195-5ECBB50EFE0A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +30,18 @@ Global
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.ReferenceModel|Any CPU.Build.0 = ReferenceModel|Any CPU
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9DA180C2-E6BD-42E3-B157-D3164F6F269F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.ReferenceModel|Any CPU.ActiveCfg = Release|Any CPU
+		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.ReferenceModel|Any CPU.Build.0 = Release|Any CPU
+		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD89FECA-46C0-4413-9BC0-C0AAA2DC8D24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.ReferenceModel|Any CPU.ActiveCfg = Release|Any CPU
+		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.ReferenceModel|Any CPU.Build.0 = Release|Any CPU
+		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F36925C-7C91-4837-8195-5ECBB50EFE0A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.sln
+++ b/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32516.85
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Configuration.ObjectFactory", "RockLib.Configuration.ObjectFactory.csproj", "{1A866445-42C8-4A9B-82C5-D3B34EBF9147}"
 EndProject

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigReloadingProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigReloadingProxyFactoryTests.cs
@@ -62,6 +62,16 @@ namespace Tests
       }
 
       [Fact]
+      public void NonDisposableInterfaceTypeThrowsArgumentException()
+      {
+         var configuration = GetConfig();
+         var interfaceType = typeof(IAmNotDisposable);
+
+         Assert.Equal("The Specified type does not implement IDisposable.",
+            Assert.Throws<ArgumentException>(() => configuration.CreateReloadingProxy(interfaceType)).Message);
+      }
+
+      [Fact]
       public void EnumerableInterfaceTypeThrowsArgumentException()
       {
          var configuration = GetConfig();
@@ -339,6 +349,11 @@ namespace Tests
       }
 
 #pragma warning disable CA1034 // Nested types should not be visible
+      public interface IAmNotDisposable 
+      {
+         void Work();
+      }
+
       public interface IFooBase
       {
          int Bar { get; }
@@ -352,8 +367,6 @@ namespace Tests
 
       public sealed class Foo : IFoo
       {
-         private bool disposedValue;
-
          public Foo(int bar)
          {
             Bar = bar;
@@ -363,34 +376,7 @@ namespace Tests
          public int Baz() => Bar * 2;
          public string? Qux { get; set; }
 
-         private void Dispose(bool disposing)
-         {
-            if (!disposedValue)
-            {
-               if (disposing)
-               {
-                  // TODO: dispose managed state (managed objects)
-               }
-
-               // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-               // TODO: set large fields to null
-               disposedValue = true;
-            }
-         }
-
-         // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-         // ~Foo()
-         // {
-         //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-         //     Dispose(disposing: false);
-         // }
-
-         public void Dispose()
-         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-         }
+         public void Dispose() { }
       }
 
       public interface IBar : IDisposable
@@ -401,8 +387,6 @@ namespace Tests
 
       public sealed class Bar : IBar
       {
-         private bool disposedValue;
-
          public Bar(int qux)
          {
             Qux = qux;
@@ -417,34 +401,7 @@ namespace Tests
             Baz?.Invoke(this, EventArgs.Empty);
          }
 
-         private void Dispose(bool disposing)
-         {
-            if (!disposedValue)
-            {
-               if (disposing)
-               {
-                  // TODO: dispose managed state (managed objects)
-               }
-
-               // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-               // TODO: set large fields to null
-               disposedValue = true;
-            }
-         }
-
-         // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-         // ~Bar()
-         // {
-         //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-         //     Dispose(disposing: false);
-         // }
-
-         public void Dispose()
-         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-         }
+         public void Dispose() { }
       }
 
       public interface IBaz : IDisposable
@@ -470,10 +427,8 @@ namespace Tests
          IGarply Garply { get; }
       }
 
-      public class Grault : IGrault
+      public sealed class Grault : IGrault
       {
-         private bool disposedValue;
-
          public Grault(int waldo, IGarply garply)
          {
             Waldo = waldo;
@@ -483,34 +438,7 @@ namespace Tests
          public int Waldo { get; }
          public IGarply Garply { get; }
 
-         protected virtual void Dispose(bool disposing)
-         {
-            if (!disposedValue)
-            {
-               if (disposing)
-               {
-                  // TODO: dispose managed state (managed objects)
-               }
-
-               // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-               // TODO: set large fields to null
-               disposedValue = true;
-            }
-         }
-
-         // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-         // ~Grault()
-         // {
-         //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-         //     Dispose(disposing: false);
-         // }
-
-         public void Dispose()
-         {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-         }
+         public void Dispose() { }
       }
 
 #pragma warning disable CA1040 // Avoid empty interfaces

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigReloadingProxyFactoryTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigReloadingProxyFactoryTests.cs
@@ -67,8 +67,15 @@ namespace Tests
          var configuration = GetConfig();
          var interfaceType = typeof(IAmNotDisposable);
 
-         Assert.Equal("The Specified type does not implement IDisposable.",
-            Assert.Throws<ArgumentException>(() => configuration.CreateReloadingProxy(interfaceType)).Message);
+         var exception = Assert.Throws<ArgumentException>(() => configuration.CreateReloadingProxy(interfaceType));
+
+#if NET48
+         Assert.Equal("The specified type, Tests.ConfigReloadingProxyFactoryTests+IAmNotDisposable, does not implement IDisposable.\r\nParameter name: interfaceType",
+            exception.Message);
+#else
+         Assert.Equal("The specified type, Tests.ConfigReloadingProxyFactoryTests+IAmNotDisposable, does not implement IDisposable. (Parameter 'interfaceType')",
+            exception.Message);
+#endif
       }
 
       [Fact]

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigurationObjectFactorySadPathTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ConfigurationObjectFactorySadPathTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 using System.Text;
 using Xunit;
 
@@ -59,7 +60,7 @@ namespace Tests
             var expected = Exceptions.CannotConvertSectionValueToTargetType(fooSection.GetSection("bar"), typeof(string), expectedInner);
 
             Assert.Equal(expected.Message, ex.Message);
-            Assert.Equal(expectedInner.Message, ex.InnerException.Message);
+            Assert.Equal(expectedInner.Message, ex.InnerException!.Message);
 #endif
       }
 
@@ -402,7 +403,7 @@ namespace Tests
 #if DEBUG
             var constructorOrderInfo = new ConstructorOrderInfo(
                 typeof(TwoArgConstructor).GetTypeInfo().GetConstructors()[0],
-                new Dictionary<string, IConfigurationSection> { { "bar", null } },
+                new Dictionary<string, IConfigurationSection> { { "bar", null! } },
                 Resolver.Empty);
             var expected = Exceptions.MissingRequiredConstructorParameters(fooSection, constructorOrderInfo);
             Assert.Equal(expected.Message, actual.Message);

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/DefaultTypesTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/DefaultTypesTests.cs
@@ -1,5 +1,6 @@
 ﻿using RockLib.Configuration.ObjectFactory;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/ValueConvertersTests.cs
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/ValueConvertersTests.cs
@@ -1,5 +1,6 @@
 ﻿using RockLib.Configuration.ObjectFactory;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Xunit;


### PR DESCRIPTION
## Description

This fixes a memory leak bug for `CreateReloadingProxy()`. This is a breaking change, which is called out in the changelog.

Link: https://github.com/RockLib/RockLib.Configuration/issues/82

## Type of change: 

2. Bug fix (non-breaking change that fixes an issue)
4. Breaking change (fix or feature that could cause existing functionality to not work as expected)