### PR TITLE
Remove .NET 6 From Configuration, MessagingProvider, and ObjectFactory

### DIFF
--- a/Examples/Example.AppConfig.DotNetFramework/Example.AppConfig.DotNetFramework.csproj
+++ b/Examples/Example.AppConfig.DotNetFramework/Example.AppConfig.DotNetFramework.csproj
@@ -4,8 +4,8 @@
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="RockLib.Configuration" Version="3.1.0" />
-		<PackageReference Include="RockLib.Configuration.ObjectFactory" Version="2.0.2" />
+		<PackageReference Include="RockLib.Configuration" Version="4.0.3" />
+		<PackageReference Include="RockLib.Configuration.ObjectFactory" Version="3.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="App.config">

--- a/Examples/Example.EnvironmentVariableConfig.DotNetCore/Example.EnvironmentVariableConfig.DotNetCore.csproj
+++ b/Examples/Example.EnvironmentVariableConfig.DotNetCore/Example.EnvironmentVariableConfig.DotNetCore.csproj
@@ -5,8 +5,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="RockLib.Configuration" Version="3.1.0" />
-		<PackageReference Include="RockLib.Configuration.ObjectFactory" Version="2.0.2" />
+		<PackageReference Include="RockLib.Configuration" Version="4.0.3" />
+		<PackageReference Include="RockLib.Configuration.ObjectFactory" Version="3.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="appsettings.json">

--- a/Examples/Example.FileConfig.DotNetCore/Example.FileConfig.DotNetCore.csproj
+++ b/Examples/Example.FileConfig.DotNetCore/Example.FileConfig.DotNetCore.csproj
@@ -5,8 +5,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="RockLib.Configuration" Version="3.1.0" />
-		<PackageReference Include="RockLib.Configuration.ObjectFactory" Version="2.0.2" />
+		<PackageReference Include="RockLib.Configuration" Version="4.0.3" />
+		<PackageReference Include="RockLib.Configuration.ObjectFactory" Version="3.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="appsettings.json">

--- a/RockLib.Configuration.AspNetCore/Directory.Build.props
+++ b/RockLib.Configuration.AspNetCore/Directory.Build.props
@@ -3,17 +3,17 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
-		<Copyright>Copyright 2023 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<Copyright>Copyright 2025 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.Configuration.AspNetCore/RockLib.Configuration.AspNetCore.csproj
+++ b/RockLib.Configuration.AspNetCore/RockLib.Configuration.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<PackageId>RockLib.Configuration.AspNetCore</PackageId>
-		<PackageVersion>3.0.1</PackageVersion>
+		<PackageVersion>4.0.0</PackageVersion>
 		<Description>Extension methods for RockLib.Configuration and ASP.NET Core.</Description>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -10,7 +10,7 @@
 		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>RockLib Configuration AspNetCore Extensions</PackageTags>
-		<Version>3.0.1</Version>
+		<Version>4.0.0</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<EmbedUntrackedSources>True</EmbedUntrackedSources>
@@ -25,7 +25,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="RockLib.Configuration" Version="4.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+		<PackageReference Include="RockLib.Configuration" Version="4.0.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
 	</ItemGroup>
 </Project>

--- a/RockLib.Configuration.MessagingProvider/CHANGELOG.md
+++ b/RockLib.Configuration.MessagingProvider/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0 - 2025-01-28
+
+#### Removed
+- Removed support for .NET 6.
+
 ## 3.1.1 - 2024-07-19
 
 #### Changed

--- a/RockLib.Configuration.MessagingProvider/Directory.Build.props
+++ b/RockLib.Configuration.MessagingProvider/Directory.Build.props
@@ -3,17 +3,17 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
-		<Copyright>Copyright 2023 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<Copyright>Copyright 2025 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.Configuration.MessagingProvider/RockLib.Configuration.MessagingProvider.csproj
+++ b/RockLib.Configuration.MessagingProvider/RockLib.Configuration.MessagingProvider.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Configuration/blob/main/RockLib.Configuration.MessagingProvider/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>Configuration Messaging</PackageTags>
-		<PackageVersion>3.1.1</PackageVersion>
+		<PackageVersion>4.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.1.1</Version>
+		<Version>4.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -29,5 +29,6 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="RockLib.Messaging" Version="4.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 </Project>

--- a/RockLib.Configuration.MessagingProvider/RockLib.Configuration.MessagingProvider.csproj
+++ b/RockLib.Configuration.MessagingProvider/RockLib.Configuration.MessagingProvider.csproj
@@ -11,9 +11,9 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Configuration/blob/main/RockLib.Configuration.MessagingProvider/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>Configuration Messaging</PackageTags>
-		<PackageVersion>4.0.0</PackageVersion>
+		<PackageVersion>4.0.0-alpha.1</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>4.0.0</Version>
+		<Version>4.0.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>

--- a/RockLib.Configuration.ObjectFactory/ConfigReloadingProxyFactory.cs
+++ b/RockLib.Configuration.ObjectFactory/ConfigReloadingProxyFactory.cs
@@ -354,7 +354,7 @@ namespace RockLib.Configuration.ObjectFactory
         }
 
         private static void AddTransferStateOverrideMethod(TypeBuilder proxyTypeBuilder, Type interfaceType,
-           IReadOnlyDictionary<EventInfo, FieldBuilder> eventFields, MethodInfo baseTransferStateMethod)
+           Dictionary<EventInfo, FieldBuilder> eventFields, MethodInfo baseTransferStateMethod)
         {
             var transferStateMethod = proxyTypeBuilder.DefineMethod("TransferState", TransferStateAttributes, typeof(void), new[] { interfaceType, interfaceType });
 

--- a/RockLib.Configuration.ObjectFactory/Directory.Build.props
+++ b/RockLib.Configuration.ObjectFactory/Directory.Build.props
@@ -3,16 +3,16 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.csproj
+++ b/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.csproj
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>RockLib.Configuration.ObjectFactory</PackageId>
-		<PackageVersion>3.0.0</PackageVersion>
+		<PackageVersion>4.0.0</PackageVersion>
 		<Authors>RockLib</Authors>
 		<Description>Creates objects from IConfiguration and IConfigurationSection objects. A replacement for some of the functionality of Microsoft.Extensions.Configuration.Binder.</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -14,7 +14,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<Copyright>Copyright 2017-2023 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<PackageTags>Configuration Factory Binder IConfiguration IConfigurationSection</PackageTags>
-		<Version>3.0.0</Version>
+		<Version>4.0.0</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<EmbedUntrackedSources>True</EmbedUntrackedSources>
@@ -27,9 +27,6 @@
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-	</ItemGroup>
-	<ItemGroup>
 		<None Include="..\LICENSE.md" Pack="true" PackagePath="" />
 		<None Include="..\icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>
@@ -37,10 +34,8 @@
 		<DefineConstants>TRACE;REFERENCE_MODEL</DefineConstants>
 		<Optimize>true</Optimize>
 	</PropertyGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="[6.0.1, 8)" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.*" />
 	</ItemGroup>
 </Project>

--- a/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.csproj
+++ b/RockLib.Configuration.ObjectFactory/RockLib.Configuration.ObjectFactory.csproj
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>RockLib.Configuration.ObjectFactory</PackageId>
-		<PackageVersion>4.0.0</PackageVersion>
+		<PackageVersion>4.0.0-alpha.1</PackageVersion>
 		<Authors>RockLib</Authors>
 		<Description>Creates objects from IConfiguration and IConfigurationSection objects. A replacement for some of the functionality of Microsoft.Extensions.Configuration.Binder.</Description>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -14,7 +14,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<Copyright>Copyright 2017-2023 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<PackageTags>Configuration Factory Binder IConfiguration IConfigurationSection</PackageTags>
-		<Version>4.0.0</Version>
+		<Version>4.0.0-alpha.1</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 		<EmbedUntrackedSources>True</EmbedUntrackedSources>

--- a/RockLib.Configuration.ProxyFactory/Directory.Build.props
+++ b/RockLib.Configuration.ProxyFactory/Directory.Build.props
@@ -3,16 +3,16 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-        <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+        <AnalysisMode>all</AnalysisMode>
         <Authors>Rocket Mortgage</Authors>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.Configuration/CHANGELOG.md
+++ b/RockLib.Configuration/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.0.0 - 2025-01-28
+
+#### Changed
+- Updated `CompositeConfigurationSection`, `MemoryConfigurationBuilderExtensions`, and `Config` members for nullability.
+- Updated Microsoft NuGet package references to latest 8.* versions.
+
+#### Removed
+- Removed support for .NET 6.
+
 ## 4.0.3 - 2024-07-12
 
 #### Added

--- a/RockLib.Configuration/CompositeConfigurationSection.cs
+++ b/RockLib.Configuration/CompositeConfigurationSection.cs
@@ -54,7 +54,7 @@ namespace RockLib.Configuration
 
         public string Path => _primarySection.Value.Path;
 
-        public string Value
+        public string? Value
         {
 #if NET8_0_OR_GREATER
 #pragma warning disable CS8603 // Possible null reference return.

--- a/RockLib.Configuration/Config.cs
+++ b/RockLib.Configuration/Config.cs
@@ -95,7 +95,7 @@ namespace RockLib.Configuration
         /// </summary>
         /// <param name="additionalValues">When specified, these key/value pairs are applied to the resulting
         /// instance of <see cref="IConfiguration"/>.</param>
-        public static void ResetRoot(IEnumerable<KeyValuePair<string, string>>? additionalValues = null)
+        public static void ResetRoot(IEnumerable<KeyValuePair<string, string?>>? additionalValues = null)
         {
             if (additionalValues is null)
             {
@@ -122,7 +122,7 @@ namespace RockLib.Configuration
             _basePath = basePath ?? Directory.GetCurrentDirectory();
         }
 
-        private static IConfiguration GetDefaultRoot(IEnumerable<KeyValuePair<string, string>>? additionalValues)
+        private static IConfiguration GetDefaultRoot(IEnumerable<KeyValuePair<string, string?>>? additionalValues)
         {
             var builder = new ConfigurationBuilder();
 

--- a/RockLib.Configuration/Directory.Build.props
+++ b/RockLib.Configuration/Directory.Build.props
@@ -3,16 +3,16 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.Configuration/RockLib.Configuration.csproj
+++ b/RockLib.Configuration/RockLib.Configuration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Copyright>Copyright 2017-2023 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<Copyright>Copyright 2017-2025 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<DebugType>Embedded</DebugType>
 		<Description>Provides a central location for an instance of IConfigurationRoot to be used as the "default" configuration by .NET libraries and applications. Replaces some of the functionality of the .NET Framework System.Configuration.ConfigurationManager class.</Description>
 		<EmbedUntrackedSources>True</EmbedUntrackedSources>
@@ -10,11 +10,11 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Configuration/blob/main/RockLib.Configuration/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageProjectUrl>https://github.com/RockLib/RockLib.Configuration</PackageProjectUrl>
-		<PackageVersion>4.0.3</PackageVersion>
+		<PackageVersion>5.0.0</PackageVersion>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>Configuration ConfigurationRoot IConfigurationRoot ConfigurationManager AppSettings</PackageTags>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>4.0.3</Version>
+		<Version>5.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>
@@ -25,13 +25,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="[6.0.1, 8)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[6.0.1, 8)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[6.0.0, 8)" />
-		<PackageReference Include="System.Text.Json" Version="6.*" />		
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.*" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.*" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.*" />

--- a/RockLib.Configuration/RockLib.Configuration.csproj
+++ b/RockLib.Configuration/RockLib.Configuration.csproj
@@ -10,11 +10,11 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Configuration/blob/main/RockLib.Configuration/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageProjectUrl>https://github.com/RockLib/RockLib.Configuration</PackageProjectUrl>
-		<PackageVersion>5.0.0</PackageVersion>
+		<PackageVersion>5.0.0-alpha.1</PackageVersion>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>Configuration ConfigurationRoot IConfigurationRoot ConfigurationManager AppSettings</PackageTags>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>5.0.0</Version>
+		<Version>5.0.0-alpha.1</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>

--- a/Tests/RockLib.Configuration.AppSettingsConfigTests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.AppSettingsConfigTests/Directory.Build.props
@@ -3,16 +3,16 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.AppSettingsConfigTests/RockLib.Configuration.AppSettingsConfigTests.csproj
+++ b/Tests/RockLib.Configuration.AppSettingsConfigTests/RockLib.Configuration.AppSettingsConfigTests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.AspNetCore.Tests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.AspNetCore.Tests/Directory.Build.props
@@ -3,17 +3,17 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
-		<Copyright>Copyright 2023 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<Copyright>Copyright 2025 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.AspNetCore.Tests/RockLib.Configuration.AspNetCore.Tests.csproj
+++ b/Tests/RockLib.Configuration.AspNetCore.Tests/RockLib.Configuration.AspNetCore.Tests.csproj
@@ -4,13 +4,13 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="xunit" Version="2.6.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.CustomConfigTests/ConfigTests.cs
+++ b/Tests/RockLib.Configuration.CustomConfigTests/ConfigTests.cs
@@ -15,7 +15,7 @@ public class ConfigTests
     {
         _configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(
-                new Dictionary<string, string>
+                new Dictionary<string, string?>
                 {
                     { "AppSettings:Environment", "Test" },
                     { "AppSettings:ApplicationId", "200001" }

--- a/Tests/RockLib.Configuration.CustomConfigTests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.CustomConfigTests/Directory.Build.props
@@ -3,16 +3,16 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.CustomConfigTests/RockLib.Configuration.CustomConfigTests.csproj
+++ b/Tests/RockLib.Configuration.CustomConfigTests/RockLib.Configuration.CustomConfigTests.csproj
@@ -1,24 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="[6.0.1, 8)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[6, 8)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[6.0.1, 8)" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[6.0.0, 8)" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.*" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.*" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.*" />

--- a/Tests/RockLib.Configuration.MessagingProvider.Tests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.MessagingProvider.Tests/Directory.Build.props
@@ -3,17 +3,17 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
-		<Copyright>Copyright 2023 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<Copyright>Copyright 2025 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.MessagingProvider.Tests/RockLib.Configuration.MessagingProvider.Tests.csproj
+++ b/Tests/RockLib.Configuration.MessagingProvider.Tests/RockLib.Configuration.MessagingProvider.Tests.csproj
@@ -13,14 +13,14 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="Moq" Version="4.20.70" />
-		<PackageReference Include="xunit" Version="2.6.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/Directory.Build.props
@@ -3,16 +3,16 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.ObjectFactory.Tests/RockLib.Configuration.ObjectFactory.Tests.csproj
+++ b/Tests/RockLib.Configuration.ObjectFactory.Tests/RockLib.Configuration.ObjectFactory.Tests.csproj
@@ -8,22 +8,19 @@
 		<DefineConstants>TRACE;REFERENCE_MODEL</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-		<PackageReference Include="xunit" Version="2.6.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="[6.0.1, 8)" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.*" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/Directory.Build.props
@@ -3,16 +3,16 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-        <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+        <AnalysisMode>all</AnalysisMode>
         <Authors>Rocket Mortgage</Authors>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.ProxyFactory.Tests/RockLib.Configuration.ProxyFactory.Tests.csproj
+++ b/Tests/RockLib.Configuration.ProxyFactory.Tests/RockLib.Configuration.ProxyFactory.Tests.csproj
@@ -4,14 +4,14 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="Moq" Version="4.20.70" />
-		<PackageReference Include="xunit" Version="2.6.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.Tests/CompositeSectionTests.cs
+++ b/Tests/RockLib.Configuration.Tests/CompositeSectionTests.cs
@@ -15,7 +15,7 @@ public class CompositeSectionTests
     public void CompositeSectionCombinesSections()
     {
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 { "foo.bar:garply:baz", "123" },
                 { "foo_bar:garply:qux", "abc" },
@@ -40,7 +40,7 @@ public class CompositeSectionTests
     public void CompositeSectionPathOrderIsSignificant()
     {
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 { "foo_bar:garply:baz", "abc" }, // Both of these settings have
                 { "foo.bar:garply:baz", "123" }, // the same composite path.
@@ -63,7 +63,7 @@ public class CompositeSectionTests
     public void GetChildrenMaintainsOrderWhenTheChildAreListItemsAndTheSecondItemComesFromTheFirstSectionOfTheCompositeSection()
     {
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 { "second_section:0:baz", "abc" },
                 { "first_section:1:baz", "xyz" },

--- a/Tests/RockLib.Configuration.Tests/Directory.Build.props
+++ b/Tests/RockLib.Configuration.Tests/Directory.Build.props
@@ -3,16 +3,16 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>all</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48'">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Tests/RockLib.Configuration.Tests/RockLib.Configuration.Tests.csproj
+++ b/Tests/RockLib.Configuration.Tests/RockLib.Configuration.Tests.csproj
@@ -4,13 +4,13 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>


### PR DESCRIPTION
## Description

Note that all projects have been updated, but only the three mentioned in the title will be released as the others depend on these.

## Type of change: 

4. Breaking change (fix or feature that could cause existing functionality to not work as expected)
